### PR TITLE
ci: fix `yarn component:new` script

### DIFF
--- a/_templates/component/with-prompt/reactComponent.ejs.t
+++ b/_templates/component/with-prompt/reactComponent.ejs.t
@@ -2,7 +2,6 @@
 to: src/components/<%= h.changeCase.pascalCase(name)  %>/<%= h.changeCase.pascalCase(name)  %>.tsx
 ---
 import React from 'react';
-import './<%= h.changeCase.camelCase(name) %>.scss';
 
 export interface <%= h.changeCase.pascalCase(name) %>Props {}
 

--- a/_templates/component/with-prompt/reactComponentStory.ejs.t
+++ b/_templates/component/with-prompt/reactComponentStory.ejs.t
@@ -1,12 +1,8 @@
 ---
 to: src/components/<%= h.changeCase.pascalCase(name) %>/<%= h.changeCase.pascalCase(name) %>.stories.tsx
 ---
+import { storiesOf } from '@storybook/react';
 import React from 'react';
+import { <%= h.changeCase.pascalCase(name) %> } from '.';
 
-export interface <%= h.changeCase.pascalCase(name) %>Props {}
-
-export const <%= h.changeCase.pascalCase(name) %>: React.FC<<%= h.changeCase.pascalCase(name) %>Props> = ({ children }) => {
-  return (
-    <div>{ children }</div>
-  );
-}
+storiesOf('<%= h.changeCase.pascalCase(name) %>', module).add('Default', () => <<%= h.changeCase.pascalCase(name) %> />);

--- a/_templates/component/with-prompt/reactComponentStyle.ejs.t
+++ b/_templates/component/with-prompt/reactComponentStyle.ejs.t
@@ -1,3 +1,0 @@
----
-to: src/components/<%= h.changeCase.pascalCase(name) %>/<%= h.changeCase.camelCase(name) %>.scss
----


### PR DESCRIPTION
Changed the output of the `yarn component:new` script.

Now, the script won't create `.scss` files and the storybook files are now correctly importing the component.