### PR TITLE
Add storybook deployments with chromatic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test-lint-build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,3 +29,15 @@ jobs:
         run: yarn test
       - name: Build
         run: yarn build
+  chromatic-deployment:
+    runs-on: ubuntu-latest
+    # Job steps
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install dependencies
+        run: yarn
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ yarn-error.log
 /coverage
 
 dist
+/storybook-static
+build-storybook.log

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "test:watch": "yarn test --watch",
     "test:coverage": "jest --coverage --colors",
     "storybook": "start-storybook -p 9001 -s ./packages/components/src/assets -c .storybook",
+    "build-storybook": "build-storybook",
+    "chromatic": "chromatic  --exit-zero-on-changes",
     "postinstall": "preconstruct dev"
   },
   "devDependencies": {
@@ -33,6 +35,7 @@
     "@preconstruct/cli": "^2.1.5",
     "@testing-library/jest-dom": "^5.15.1",
     "@testing-library/react": "^12.1.2",
+    "chromatic": "^6.1.0",
     "jest": "^26.6.3",
     "msw": "^0.35.0",
     "ts-jest": "^26.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5697,6 +5697,11 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
+chromatic@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-6.1.0.tgz#0228eba1a01f713a3f5109b7e4f4dbaa4e1a5169"
+  integrity sha512-XJT0VIOKYE9RwKTAOcLVpoYqJCU3/+58gOd8Why12sef6WJ7qjeO4c2Vn5ngpM+9A9PwE+y+ULQS25ThSd6WNA==
+
 chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"


### PR DESCRIPTION
This PR adds automatic Storybook deployments and closes [#49](https://github.com/Developer-DAO/web3-ui/issues/49)

A Preview can be found [here](https://61a87bd8f320d9003aa6253f-cammlazviw.chromatic.com/?path=/story/address--default)

## Some things to consider

The free plan includes 5000 snapshots / month. From the [docs](https://www.chromatic.com/pricing#FAQSection):
 ```
Everytime you run a build, we take one snapshot for each story.
If you have 50 stories, Chromatic will take 50 snapshots.
In addition, testing multiple viewports and browsers are also considered snapshots.
```
Currently thats the only limitation we might encounter, the free plan allow unlimited seats and collaborator. So we could assign reviewer if there are major UI changes that need approval.

![image](https://user-images.githubusercontent.com/6060101/144585890-b53e7958-86be-4fa7-8c0c-2c04d119ae0b.png)

## Preview Fork deployments

It would be possible to have a deployment deployments for [each fork](https://www.chromatic.com/docs/github-actions#forked-repositories) if we want.

## TODOs

@with-heart @Dhaiwat10 or someone with access to the Developer-DAO github account has to link the project to chromatic.
https://www.chromatic.com/docs/setup

Add chromatics token as secret https://www.chromatic.com/docs/github-actions#forked-repositories


