### PR TITLE
chore: add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,41 @@
+name: "Component/Hook Request"
+description: "Add suggestion for a component and/or a hook"
+labels: ["feature"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        Thanks for creating an issue!
+
+        Make sure to search open/closed issues before submitting.
+  - type: "textarea"
+    id: "description"
+    attributes:
+      label: "Description"
+      description: "Please describe your idea in one or two sentences."
+    validations:
+      required: true
+  - type: "textarea"
+    id: "justification"
+    attributes:
+      label: "Why is this needed?"
+      description: |
+        Please explain why you believe this is needed.
+    validations:
+      required: true
+  - type: "textarea"
+    id: "proposed-solution"
+    attributes:
+      label: "Proposed Solution or API"
+      description: |
+        Please share what you believe the ideal design/API should be like.
+        You can use code snippets, gists, or links to communicate it.
+    validations:
+      required: true
+  - type: "textarea"
+    id: "additional-information"
+    attributes:
+      label: "Additional Information"
+      description: |
+        What resources (links, screenshots, etc.) do you have to assist this
+        effort?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!---
+Thanks for creating a Pull Request!
+
+Please read the following before submitting:
+- Keep your PR as small as possible.
+- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
+- Reference the issue you're modifying.
+-->
+
+Closes # <!-- Github issue # here -->
+
+## Description
+
+> Add a brief description
+
+## 📝 Additional Information
+
+> Anything else you'd want reviewers to know.
+<!--- Remember:
+ You have a lot more context than whoever is going to review.
+ The more details you provide, the easier you make for others
+ to review the PRs.
+-->
+
+<!---
+## Screenshot
+
+If your changes are visual, please add a screenshot.
+If they're behavioral, consider adding a screen recording of the change.
+-->


### PR DESCRIPTION
## Description

While going through the issues in this repo, I realised one of the PRs had not been linked to an issue, which in turn made me realise we don't have a standard template for adding PRs or issues. 

Templates introduce a bit more consistency in general.

I tried to keep it simple and to the point.

I took inspiration from Chakra's templates and modified them to our use case.
