### PR TITLE
Update docs to recommend cloning instead of forking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ To setup your local dev environment:
 # Install `yarn`, alternatives at https://yarnpkg.com/en/docs/install
 curl -o- -L https://yarnpkg.com/install.sh | bash
 
-# Fork web3-ui in the Github UI and clone it
-git clone git@github.com:<GITHUB_USERNAME>/web3-ui.git
+# Clone the repo
+git clone git@github.com:Developer-DAO/web3-ui.git
 cd web3-ui
 
 # web3-ui uses Node 16. We recommend using nvm to locally manage node versions.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is built with the following open source libraries, frameworks and l
 
 3. Ask other contributors to see if no one has taken the issue yet. If you're interested in tackling such a feature and it's still available, we will assign you to the task.
 
-4. Fork the repo and create your own branch using `git checkout -b your_branch_name`. Remember to use a branch name that describes WHAT you're doing/fixing.
+4. Clone the repo and create your own branch using `git checkout -b your_branch_name`. Remember to use a branch name that describes WHAT you're doing/fixing.
 
 5. Setup your local development environment. Instructions [here](/CONTRIBUTING.md#installation)
 


### PR DESCRIPTION
After adding chromatic, we should be opening PRs off of branches within the repo, that way the ci checks work