### PR TITLE
set Storybook default viewmode to "Docs"

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,3 +8,8 @@ export const decorators = [
     </ChakraProvider>
   ),
 ];
+
+export const parameters = {
+  controls: { expanded: true },
+  viewMode: 'docs',
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request!

Please read the following before submitting:
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- Reference the issue you're modifying.
-->

## Description

Set the `Docs` tab as a default view mode for stories in Storybook.

![image](https://user-images.githubusercontent.com/19361575/145287511-fe6e19b0-e903-4a21-b5ec-ae1998a51e08.png)


## 📝 Additional Information

⚠️ You might notice that the initial render of the Storybook has the `Canvas` tab open and only after clicking on a different story it would start defaulting to `Docs`. I've checked with my other Storybook projects that use this addon - same behaviour. 

Suboptimal, but quite minor tbf
<!--- Remember:
 You have a lot more context than whoever is going to review.
 The more details you provide, the easier you make for others
 to review the PRs.
-->

<!---
## Screenshot

If your changes are visual, please add a screenshot.
If they're behavioral, consider adding a screen recording of the change.
-->
