### PR TITLE
Address: can copy address to clipboard

### DIFF
--- a/.changeset/brown-trainers-float.md
+++ b/.changeset/brown-trainers-float.md
@@ -1,0 +1,5 @@
+---
+'@web3-ui/components': minor
+---
+
+Address component now accept copiable prop to allow users to copy the address value into their clipboard

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -27,6 +27,7 @@
   "module": "dist/web3-ui-components.esm.js",
   "types": "dist/web3-ui-components.cjs.d.ts",
   "dependencies": {
+    "@chakra-ui/icons": "^1.1.1",
     "@chakra-ui/react": "^1.7.2",
     "@emotion/core": "^11.0.0",
     "@emotion/react": "^11",

--- a/packages/components/src/components/Address/Address.stories.tsx
+++ b/packages/components/src/components/Address/Address.stories.tsx
@@ -17,6 +17,7 @@ const AddressUsingProvider = () => {
   return (
     <>
       <Address
+        copiable
         value={connected ? connection.ens || connection.userAddress || '' : 'Not connected'}
       />
       <Button onClick={connectWallet}>Connect wallet</Button>
@@ -29,3 +30,5 @@ export const WithWallet = () => (
     <AddressUsingProvider />
   </Provider>
 );
+
+export const CanBeCopied = () => <Address value='0x00000000000000' copiable />;

--- a/packages/components/src/components/Address/Address.test.tsx
+++ b/packages/components/src/components/Address/Address.test.tsx
@@ -1,11 +1,45 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { jest } from '@jest/globals';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 
 import { Address } from './Address';
 
+Object.assign(navigator, {
+  clipboard: {
+    writeText: () => {},
+  },
+});
+
 describe('Address', () => {
   it('renders without throwing', () => {
-    const { container } = render(<Address value="taylorswift.eth" />);
+    const { container } = render(<Address value='taylorswift.eth' />);
     expect(container).toBeInTheDocument();
+  });
+});
+
+describe('Address copiable prop true', () => {
+  it('renders without throwing', () => {
+    const { container } = render(<Address copiable value='taylorswift.eth' />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders with icon', () => {
+    const { container } = render(<Address copiable value='taylorswift.eth' />);
+    const svg = container.querySelector('svg') as SVGElement;
+
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('uses writeText from Clipboard API', async () => {
+    const { container } = render(<Address copiable value='taylorswift.eth' />);
+    const input = container.querySelector('input') as HTMLElement;
+
+    jest.spyOn(navigator.clipboard, 'writeText');
+
+    fireEvent.click(input);
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('taylorswift.eth');
+    });
   });
 });

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -59,7 +59,7 @@ export const Address: React.FC<AddressProps> = ({ value, copiable = false }) => 
             children={copied ? <CheckIcon color='green.500' /> : <CopyIcon color='gray.300' />}
           />
         )}
-        <Input value={value} onClick={handleClick} />
+        <Input value={value} onClick={handleClick} readOnly />
       </InputGroup>
       <FormErrorMessage>{error}</FormErrorMessage>
     </FormControl>

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -1,16 +1,67 @@
-import { Input } from '@chakra-ui/react';
-import React from 'react';
+import {
+  FormControl,
+  FormErrorMessage,
+  Input,
+  InputGroup,
+  InputRightElement,
+} from '@chakra-ui/react';
+import { CopyIcon, CheckIcon } from '@chakra-ui/icons';
+import React, { useState } from 'react';
 
 export interface AddressProps {
   /**
    * The address to display
    */
   value: string;
+  /**
+   * Wheter the address can be copied or not
+   */
+  copiable?: boolean;
+}
+
+interface EventTarget {
+  value: string;
+}
+
+interface SyntheticEvent {
+  currentTarget: EventTarget;
 }
 
 /**
  * A component to display an address
  */
-export const Address: React.FC<AddressProps> = ({ value }) => {
-  return <Input value={value} />;
+export const Address: React.FC<AddressProps> = ({ value, copiable = false }) => {
+  const [error, setError] = useState<null | string>(null);
+  const [copied, setCopied] = useState<boolean>(false);
+
+  const handleClick = async (event: SyntheticEvent): Promise<void> => {
+    const value = event.currentTarget.value as string;
+
+    setError(null);
+    setCopied(false);
+
+    if (copiable && value) {
+      try {
+        await navigator.clipboard.writeText(value);
+        setCopied(true);
+      } catch (error) {
+        setError(error as string);
+      }
+    }
+  };
+
+  return (
+    <FormControl isInvalid={!!error}>
+      <InputGroup>
+        {copiable && (
+          <InputRightElement
+            pointerEvents='none'
+            children={copied ? <CheckIcon color='green.500' /> : <CopyIcon color='gray.300' />}
+          />
+        )}
+        <Input value={value} onClick={handleClick} />
+      </InputGroup>
+      <FormErrorMessage>{error}</FormErrorMessage>
+    </FormControl>
+  );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1333,6 +1333,14 @@
   dependencies:
     "@chakra-ui/utils" "1.9.1"
 
+"@chakra-ui/icons@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/icons/-/icons-1.1.1.tgz#e4b191fd38be999c4434ff2b1fb69a5eaf3cf226"
+  integrity sha512-/+u6euCOFw6J1DZW7NcVFtib4mygJBoqRdsKiU1Z3uiTC+zQTBzcCt54NQ+kK8rhuNzJ+odahnt/AbjBJgZ+5A==
+  dependencies:
+    "@chakra-ui/icon" "1.2.1"
+    "@types/react" "^17.0.15"
+
 "@chakra-ui/image@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@chakra-ui/image/-/image-1.1.1.tgz#39ecb77155e9e1fbbc68e825eb46405808805a8c"
@@ -4499,7 +4507,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.36":
+"@types/react@*", "@types/react@^17.0.15", "@types/react@^17.0.36":
   version "17.0.37"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.37.tgz#6884d0aa402605935c397ae689deed115caad959"
   integrity sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==


### PR DESCRIPTION
Let's wait for PR#95 to be merged first and I'll fix any conflicts

Closes #86 

## Description

This PR includes changes to make the Address component copiable to clipboard. We're now able to provide a prop `<Address value='0x000' copiable />` to enable users to copy the address to their clipboard.

## What changed

- New prop on `Address` called `copiable` as type `boolean` - default is falsy
- When `copiable` is set to `true` we're now displaying a Copy Icon on the far right of the input - This allows users to know they can copy the address to their clipboard
- When users successfully copied the address to their clipboard we're replacing the Copy Icon by a Check Icon as a success feedback
- Added error state to notify users if copy to clipboard has failed

## 📝 Additional Information

I have added `@chakra-ui/icons` package to add icons, thinking that's the most suitable for us atm as we're already using chakraUI - any concerns let me know


## Screenshot

copiable set to true:
![copiable set to true](https://i.imgur.com/vqHJPlg.png)

copied successfully:
![copied](https://i.imgur.com/FC8rDcI.png)
