### PR TITLE
(chore) - add readme and license to published package

### DIFF
--- a/.changeset/heavy-ladybugs-marry.md
+++ b/.changeset/heavy-ladybugs-marry.md
@@ -1,0 +1,7 @@
+---
+'@web3-ui/components': patch
+'@web3-ui/core': patch
+'@web3-ui/hooks': patch
+---
+
+Add README and LICENSE to published packages

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_STORE
+packages/**/LICENSE
+packages/**/README.md
 
 node_modules
 .rpt2_cache

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -21,7 +21,8 @@
     "build": "preconstruct build",
     "format": "prettier --write \"src/**/*.{ts,tsx,json,js,jsx}\"",
     "format:check": "prettier --list-different \"src/**/*.{ts,tsx,json,js,jsx}\"",
-    "pre-commit-hook": "yarn lint-staged"
+    "pre-commit-hook": "yarn lint-staged",
+    "prepublishOnly": "cp ../../LICENSE ./LICENSE && cp ../../README.md ./README.md"
   },
   "main": "dist/web3-ui-components.cjs.js",
   "module": "dist/web3-ui-components.esm.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,8 @@
     "build": "preconstruct build",
     "format": "prettier --write \"src/**/*.{ts,tsx,json,js,jsx}\"",
     "format:check": "prettier --list-different \"src/**/*.{ts,tsx,json,js,jsx}\"",
-    "pre-commit-hook": "yarn lint-staged"
+    "pre-commit-hook": "yarn lint-staged",
+    "prepublishOnly": "cp ../../LICENSE ./LICENSE && cp ../../README.md ./README.md"
   },
   "main": "dist/web3-ui-core.cjs.js",
   "module": "dist/web3-ui-core.esm.js",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -24,7 +24,8 @@
     "test": "jest --maxWorkers=2",
     "test:watch": "yarn test --watch",
     "test:coverage": "jest --coverage --colors --maxWorkers=2",
-    "pre-commit-hook": "yarn lint-staged"
+    "pre-commit-hook": "yarn lint-staged",
+    "prepublishOnly": "cp ../../LICENSE ./LICENSE && cp ../../README.md ./README.md"
   },
   "main": "dist/web3-ui-hooks.cjs.js",
   "module": "dist/web3-ui-hooks.esm.js",


### PR DESCRIPTION
Closes #87

## Description

This copies over the `README` and `LICENSE` from the root to the package before we publish to npm. Personally in the future I'd go for `README` files for each package that contain minimal information as to how the package works, how to install it and the version/test-coverage/...
