### PR TITLE
include regenerator runtime babel runtime vars

### DIFF
--- a/.changeset/gold-phones-unite.md
+++ b/.changeset/gold-phones-unite.md
@@ -1,0 +1,7 @@
+---
+'@web3-ui/components': patch
+'@web3-ui/core': patch
+'@web3-ui/hooks': patch
+---
+
+Add babel-runtime to deps so we can have regenerator runtime at runtime

--- a/packages/components/.babelrc
+++ b/packages/components/.babelrc
@@ -3,5 +3,8 @@
     "@babel/preset-env",
     "@babel/preset-typescript",
     "@babel/preset-react"
+  ],
+  "plugins": [
+    "@babel/plugin-transform-runtime"
   ]
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -28,6 +28,7 @@
   "module": "dist/web3-ui-components.esm.js",
   "types": "dist/web3-ui-components.cjs.d.ts",
   "dependencies": {
+    "@babel/runtime": "^7.16.3",
     "@chakra-ui/react": "^1.7.2",
     "@emotion/core": "^11.0.0",
     "@emotion/react": "^11",

--- a/packages/core/.babelrc
+++ b/packages/core/.babelrc
@@ -1,3 +1,10 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript", "@babel/preset-react"]
+  "presets": [
+    "@babel/preset-env",
+    "@babel/preset-typescript",
+    "@babel/preset-react"
+  ],
+  "plugins": [
+    "@babel/plugin-transform-runtime"
+  ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
   "module": "dist/web3-ui-core.esm.js",
   "types": "dist/web3-ui-core.cjs.d.ts",
   "dependencies": {
+    "@babel/runtime": "^7.16.3",
     "@chakra-ui/react": "^1.7.2",
     "@emotion/core": "^11.0.0",
     "@emotion/react": "^11",

--- a/packages/hooks/.babelrc
+++ b/packages/hooks/.babelrc
@@ -3,5 +3,8 @@
     "@babel/preset-env",
     "@babel/preset-typescript",
     "@babel/preset-react"
+  ],
+  "plugins": [
+    "@babel/plugin-transform-runtime"
   ]
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -31,6 +31,7 @@
   "module": "dist/web3-ui-hooks.esm.js",
   "types": "dist/web3-ui-hooks.cjs.d.ts",
   "dependencies": {
+    "@babel/runtime": "^7.16.3",
     "@rsksmart/rlogin-ledger-provider": "^1.0.1",
     "@walletconnect/web3-provider": "^1.6.6",
     "ethers": "^5.5.1",


### PR DESCRIPTION
Closes #115

## Description

preconstruct doesn't automatically include `regeneratorRuntime` this fixes that crash