### PR TITLE
Add `switchToCorrectNetwork` method

### DIFF
--- a/.changeset/long-buses-brush.md
+++ b/.changeset/long-buses-brush.md
@@ -1,0 +1,5 @@
+---
+'@web3-ui/hooks': minor
+---
+
+Added a new method "switchToCorrectNetwork" to the useWallet hook. This method allows the user to switch to the required network without manually heading over to the MetaMask and switching the network. Users can use this function by directly passing this method in the click handler of a button.

--- a/packages/hooks/src/Provider.tsx
+++ b/packages/hooks/src/Provider.tsx
@@ -13,7 +13,7 @@ export interface Web3ContextType {
   connected: boolean;
   provider?: ethers.providers.Web3Provider | null;
   correctNetwork: boolean;
-  requiredNetwork: number;
+  network: number;
 }
 
 export const Web3Context = React.createContext<Web3ContextType | undefined>(undefined);
@@ -159,7 +159,6 @@ export const Provider: React.FC<ProviderProps> = ({
       network,
       chainId,
       correctNetwork,
-      requiredNetwork: network,
     }),
     [
       connectWallet,

--- a/packages/hooks/src/Provider.tsx
+++ b/packages/hooks/src/Provider.tsx
@@ -13,6 +13,7 @@ export interface Web3ContextType {
   connected: boolean;
   provider?: ethers.providers.Web3Provider | null;
   correctNetwork: boolean;
+  requiredNetwork: number;
 }
 
 export const Web3Context = React.createContext<Web3ContextType | undefined>(undefined);
@@ -158,6 +159,7 @@ export const Provider: React.FC<ProviderProps> = ({
       network,
       chainId,
       correctNetwork,
+      requiredNetwork: network,
     }),
     [
       connectWallet,

--- a/packages/hooks/src/hooks/useWallet.ts
+++ b/packages/hooks/src/hooks/useWallet.ts
@@ -43,8 +43,10 @@ export function useWallet() {
           params: [{ chainId: `0x${requiredNetwork}` }], // chainId must be in hexadecimal numbers
         });
       } catch (error) {
-        // This error code indicates that the chain has not been added to MetaMask
-        // if it is not, then install it into the user MetaMask
+        console.error(error);
+        // This error code indicates that the chain has not been added to MetaMask.
+        // If it is not, then install it into the user MetaMask
+        // @ts-ignore
         if (error.code === 4902) {
           try {
             await window.ethereum.request({
@@ -60,7 +62,6 @@ export function useWallet() {
             console.error(addError);
           }
         }
-        console.error(error);
       }
     } else {
       // if no window.ethereum then MetaMask is not installed

--- a/packages/hooks/src/hooks/useWallet.ts
+++ b/packages/hooks/src/hooks/useWallet.ts
@@ -22,7 +22,7 @@ export function useWallet() {
     connected,
     provider,
     correctNetwork,
-    requiredNetwork,
+    network,
   } = context;
 
   React.useEffect(() => {
@@ -37,10 +37,11 @@ export function useWallet() {
     if (window.ethereum) {
       try {
         console.log('chainId', { chainId });
+        console.log('requiredNetwork', { network });
         // check if the chain to connect to is installed
         await window.ethereum.request({
           method: 'wallet_switchEthereumChain',
-          params: [{ chainId: `0x${requiredNetwork}` }], // chainId must be in hexadecimal numbers
+          params: [{ chainId: `0x${network}` }], // chainId must be in hexadecimal numbers
         });
       } catch (error) {
         console.error(error);

--- a/packages/hooks/src/hooks/useWallet.ts
+++ b/packages/hooks/src/hooks/useWallet.ts
@@ -46,8 +46,8 @@ export function useWallet() {
       } catch (error) {
         console.error(error);
         // This error code indicates that the chain has not been added to MetaMask.
-        // If it is not, then install it into the user MetaMask
-        // @ts-ignore
+        // If it is not, then install it into the user's MetaMask
+        // @ts-expect-error
         if (error.code === 4902) {
           try {
             await window.ethereum.request({
@@ -65,9 +65,9 @@ export function useWallet() {
         }
       }
     } else {
-      // if no window.ethereum then MetaMask is not installed
+      // if window.ethereum is undefined then MetaMask is not installed
       alert(
-        'MetaMask is not installed. Please consider installing it: https://metamask.io/download.html'
+        'Switching networks automatically is only supported in MetaMask. Please consider installing it: https://metamask.io/download.html'
       );
     }
   };

--- a/packages/hooks/src/stories/ConnectWallet.stories.tsx
+++ b/packages/hooks/src/stories/ConnectWallet.stories.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from 'react';
 import { Button } from '@chakra-ui/react';
-import { NETWORKS, Provider, useWallet } from '..';
-import Authereum from 'authereum';
 import Portis from '@portis/web3';
+import Authereum from 'authereum';
+import React, { useEffect } from 'react';
+import { NETWORKS, Provider, useWallet } from '..';
 
 export default {
   title: 'Hooks/useWallet',
@@ -10,7 +10,14 @@ export default {
 const portisDappId = '512893f6-6436-44c3-b0dc-6caccab984bb';
 
 const DefaultUsingProvider = () => {
-  const { connection, connectWallet, disconnectWallet, connected, correctNetwork } = useWallet();
+  const {
+    connection,
+    connectWallet,
+    disconnectWallet,
+    connected,
+    correctNetwork,
+    switchToCorrectNetwork,
+  } = useWallet();
 
   useEffect(() => {
     if (!correctNetwork) {
@@ -24,6 +31,11 @@ const DefaultUsingProvider = () => {
         <Button onClick={disconnectWallet}>Disconnect wallet</Button>
         <p>{connection.ens || connection.userAddress}</p>
         <p>Connected to the correct network: {correctNetwork ? 'Yes' : 'no'}</p>
+        {!correctNetwork && (
+          <Button colorScheme='teal' mt={2} onClick={switchToCorrectNetwork}>
+            Switch to correct network
+          </Button>
+        )}
       </div>
     );
   }
@@ -59,7 +71,8 @@ export const WithPortisProvider = () => (
       {
         portis: {
           display: {
-            logo: 'https://user-images.githubusercontent.com/9419140/128913641-d025bc0c-e059-42de-a57b-422f196867ce.png',
+            logo:
+              'https://user-images.githubusercontent.com/9419140/128913641-d025bc0c-e059-42de-a57b-422f196867ce.png',
             name: 'Portis',
             description: 'Connect to Portis App',
           },
@@ -82,7 +95,8 @@ export const PortisAuthereumProvider = () => (
       {
         portis: {
           display: {
-            logo: 'https://user-images.githubusercontent.com/9419140/128913641-d025bc0c-e059-42de-a57b-422f196867ce.png',
+            logo:
+              'https://user-images.githubusercontent.com/9419140/128913641-d025bc0c-e059-42de-a57b-422f196867ce.png',
             name: 'Portis',
             description: 'Connect to Portis App',
           },

--- a/packages/hooks/src/stories/ConnectWallet.stories.tsx
+++ b/packages/hooks/src/stories/ConnectWallet.stories.tsx
@@ -1,8 +1,8 @@
-import { Button } from '@chakra-ui/react';
-import Portis from '@portis/web3';
-import Authereum from 'authereum';
 import React, { useEffect } from 'react';
+import { Button } from '@chakra-ui/react';
 import { NETWORKS, Provider, useWallet } from '..';
+import Authereum from 'authereum';
+import Portis from '@portis/web3';
 
 export default {
   title: 'Hooks/useWallet',


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request!

Please read the following before submitting:
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- Reference the issue you're modifying.
-->

Closes #119 <!-- Github issue # here -->

## Description
This PR adds a method `switchToCorrectNetwork` to the `useWallet()` hook. This method allows the user to connect to the required network without manually heading over to the MetaMask and switching the network.

Users can use this method by directly assigning this `switchToCorrectNetwork` function to the `onClick` handler of any button and then the magic will happen and the MetaMask network will get changed to the required network.

In case, any user doesn't have MetaMask installed then it will show an alert to the user and ask them to install MetaMask.

