### PR TITLE
Fix/network change hooks

### DIFF
--- a/.changeset/lucky-starfishes-bow.md
+++ b/.changeset/lucky-starfishes-bow.md
@@ -1,0 +1,5 @@
+---
+'@web3-ui/hooks': patch
+---
+
+Fix issues related to accountChange and networkChange


### PR DESCRIPTION
Closes #153 
Closes #154 

- Refactored the `connectWallet` function because the value of `connection` wasn't being persisted. We were using the `connection` object as our 'provider' and hence it was throwing errors in methods like `onNetworkChanage`.

- Also added an edge case inside `accountsChanged` to detect if no accounts are connected anymore. 