### PR TITLE
Create test for useWallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@preconstruct/cli": "^2.1.5",
     "@testing-library/jest-dom": "^5.15.1",
     "@testing-library/react": "^12.1.2",
+    "@testing-library/react-hooks": "^7.0.2",
     "chromatic": "^6.1.0",
     "husky": "^7.0.4",
     "jest": "^26.6.3",

--- a/packages/hooks/src/hooks/useWallet.test.tsx
+++ b/packages/hooks/src/hooks/useWallet.test.tsx
@@ -13,42 +13,47 @@ afterEach(() => {
   windowSpy.mockRestore();
 });
 
-test('should use the wallet', () => {
-  const wrapper = ({ children }) => (
-    <Provider network={1} infuraId={'abc123'}>
-      {children}
-    </Provider>
-  );
-  const { result } = renderHook(() => useWallet(), { wrapper });
+describe('useWallet tests', () => {
+  test('should use the wallet', () => {
+    const wrapper = ({ children }) => (
+      <Provider network={1} infuraId={'abc123'}>
+        {children}
+      </Provider>
+    );
+    const { result } = renderHook(() => useWallet(), { wrapper });
 
-  expect(result.current.connected).toBe(false);
-  expect(typeof result.current.connectWallet).toBe('function');
-});
+    expect(result.current.connected).toBe(false);
+    expect(typeof result.current.connectWallet).toBe('function');
+  });
 
-// initially is chainId undefined / requires network per the argument
-test('should be able to switch networks', () => {
-  const testNetwork = 2;
-  const wrapper = ({ children }) => (
-    <Provider network={testNetwork} infuraId={'abc123'}>
-      {children}
-    </Provider>
-  );
-  const { result } = renderHook(() => useWallet(), { wrapper });
+  // initially is chainId undefined / requires network per the argument
+  test('should be able to switch networks', () => {
+    const testNetwork = 2;
+    const wrapper = ({ children }) => (
+      <Provider network={testNetwork} infuraId={'abc123'}>
+        {children}
+      </Provider>
+    );
+    const { result } = renderHook(() => useWallet(), { wrapper });
 
-  let requestArgs;
+    let requestArgs;
 
-  windowSpy.mockImplementation(() => ({
-    ethereum: {
-      request: arg => {
-        requestArgs = arg;
+    // hijack the call to window.ethereum.request to capture those args
+    // this ensures that we have values in the requestArgs if/when request is called
+    // those are checked at the end
+    windowSpy.mockImplementation(() => ({
+      ethereum: {
+        request: arg => {
+          requestArgs = arg;
+        }
       }
-    }
-  }));
+    }));
 
-  result.current.switchToCorrectNetwork();
-  expect(windowSpy).toHaveBeenCalled();
-  expect(requestArgs).toStrictEqual({
-    method: 'wallet_switchEthereumChain',
-    params: [{ chainId: `0x${testNetwork}` }]
+    result.current.switchToCorrectNetwork();
+    expect(windowSpy).toHaveBeenCalled();
+    expect(requestArgs).toStrictEqual({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: `0x${testNetwork}` }]
+    });
   });
 });

--- a/packages/hooks/src/hooks/useWallet.test.tsx
+++ b/packages/hooks/src/hooks/useWallet.test.tsx
@@ -3,20 +3,20 @@ import { useWallet } from './useWallet';
 import { Provider } from '../Provider';
 import { renderHook } from '@testing-library/react-hooks';
 
-let windowSpy;
-
-beforeEach(() => {
-  windowSpy = jest.spyOn(window, 'window', 'get');
-});
-
-afterEach(() => {
-  windowSpy.mockRestore();
-});
-
 describe('useWallet tests', () => {
-  test('should use the wallet', () => {
+  let windowSpy;
+
+  beforeEach(() => {
+    windowSpy = jest.spyOn(window, 'window', 'get');
+  });
+
+  afterEach(() => {
+    windowSpy.mockRestore();
+  });
+
+  test('should instantiate for valid input types', () => {
     const wrapper = ({ children }) => (
-      <Provider network={1} infuraId={'abc123'}>
+      <Provider network={1} infuraId="abc123">
         {children}
       </Provider>
     );
@@ -28,9 +28,9 @@ describe('useWallet tests', () => {
 
   // initially is chainId undefined / requires network per the argument
   test('should be able to switch networks', () => {
-    const testNetwork = 2;
+    const testNetwork = 111;
     const wrapper = ({ children }) => (
-      <Provider network={testNetwork} infuraId={'abc123'}>
+      <Provider network={testNetwork} infuraId="abc123">
         {children}
       </Provider>
     );
@@ -53,7 +53,12 @@ describe('useWallet tests', () => {
     expect(windowSpy).toHaveBeenCalled();
     expect(requestArgs).toStrictEqual({
       method: 'wallet_switchEthereumChain',
+      // this passes (for high number networks)
       params: [{ chainId: `0x${testNetwork}` }]
+      // The test should probably look like this
+      // if we are in fact converting network numbers to hex
+      // but fails with the current implementation
+      // params: [{ chainId: `0x${Number(testNetwork).toString(16)}` }]
     });
   });
 });

--- a/packages/hooks/src/hooks/useWallet.test.tsx
+++ b/packages/hooks/src/hooks/useWallet.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useWallet } from './useWallet';
+import { Provider } from '../Provider';
+import { renderHook } from '@testing-library/react-hooks';
+
+let windowSpy;
+
+beforeEach(() => {
+  windowSpy = jest.spyOn(window, 'window', 'get');
+});
+
+afterEach(() => {
+  windowSpy.mockRestore();
+});
+
+test('should use the wallet', () => {
+  const wrapper = ({ children }) => (
+    <Provider network={1} infuraId={'abc123'}>
+      {children}
+    </Provider>
+  );
+  const { result } = renderHook(() => useWallet(), { wrapper });
+
+  expect(result.current.connected).toBe(false);
+  expect(typeof result.current.connectWallet).toBe('function');
+});
+
+// initially is chainId undefined / requires network per the argument
+test('should be able to switch networks', () => {
+  const testNetwork = 2;
+  const wrapper = ({ children }) => (
+    <Provider network={testNetwork} infuraId={'abc123'}>
+      {children}
+    </Provider>
+  );
+  const { result } = renderHook(() => useWallet(), { wrapper });
+
+  let requestArgs;
+
+  windowSpy.mockImplementation(() => ({
+    ethereum: {
+      request: arg => {
+        requestArgs = arg;
+      }
+    }
+  }));
+
+  result.current.switchToCorrectNetwork();
+  expect(windowSpy).toHaveBeenCalled();
+  expect(requestArgs).toStrictEqual({
+    method: 'wallet_switchEthereumChain',
+    params: [{ chainId: `0x${testNetwork}` }]
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4029,6 +4029,17 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"
+  integrity sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^12.1.2":
   version "12.1.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.2.tgz#f1bc9a45943461fa2a598bb4597df1ae044cfc76"
@@ -4315,6 +4326,13 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
+  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dom@^16.9.10":
   version "16.9.14"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.14.tgz#674b8f116645fe5266b40b525777fc6bb8eb3bcd"
@@ -4329,10 +4347,26 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^17.0.15", "@types/react@^17.0.36":
   version "17.0.37"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.37.tgz#6884d0aa402605935c397ae689deed115caad959"
   integrity sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "17.0.38"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
+  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -13631,6 +13665,13 @@ react-element-to-jsx-string@^14.3.4:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "17.0.2"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-overlay@^6.0.9:
   version "6.0.9"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request!

Please read the following before submitting:
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- Reference the issue you're modifying.
-->

Closes #176 

## Description

Add @testing-library/react-hooks, make use of Provider for context and test that useWallet can instantiate and trigger the request to connect to the correct network.

## 📝 Additional Information

> Anything else you'd want reviewers to know.

Pretty basic tests, but extensible if we want to either deeply mock window.ethereum, make use of another external library (though none jump out as best-choice), or solve this in another way.
