### PR TITLE
Add check for `context.connected` in `useContract` for readiness

### DIFF
--- a/.changeset/rare-days-punch.md
+++ b/.changeset/rare-days-punch.md
@@ -2,4 +2,4 @@
 '@web3-ui/hooks': patch
 ---
 
-Add check for user connection during contract init in useContract
+`useContract` now initializes the contract only after the user has connected their wallet. This helps prevent errors from calling contracts without a connection.

--- a/.changeset/rare-days-punch.md
+++ b/.changeset/rare-days-punch.md
@@ -1,0 +1,5 @@
+---
+'@web3-ui/hooks': patch
+---
+
+Add check for user connection during contract init in useContract

--- a/packages/hooks/src/hooks/useContract.ts
+++ b/packages/hooks/src/hooks/useContract.ts
@@ -7,7 +7,7 @@ export function useContract(address: string, abi) {
   const [contract, setContract] = React.useState({});
   const [isReady, setIsReady] = React.useState(false);
   React.useEffect(() => {
-    if (context && context.connected) {
+    if (context?.connected) {
       const newContract = new Contract(
         address,
         abi,

--- a/packages/hooks/src/hooks/useContract.ts
+++ b/packages/hooks/src/hooks/useContract.ts
@@ -7,7 +7,7 @@ export function useContract(address: string, abi) {
   const [contract, setContract] = React.useState({});
   const [isReady, setIsReady] = React.useState(false);
   React.useEffect(() => {
-    if (context) {
+    if (context && context.connected) {
       const newContract = new Contract(
         address,
         abi,


### PR DESCRIPTION
This PR introduces a new check in the `useContract` hook which only attempts to initalize the contract if the user has connected their wallet. Calling contracts when the user hadn't connected their wallet was throwing errors.