### PR TITLE
Add generic type argument for useContract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # web3-ui
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-
 [![All Contributors](https://img.shields.io/badge/all_contributors-21-orange.svg?style=flat-square)](#contributors-)
-
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 _In Development 🏗️_

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,5 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+types
+
 # dependencies
 /node_modules
 /.pnp

--- a/example/abis/Greeter.json
+++ b/example/abis/Greeter.json
@@ -1,0 +1,52 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_greeting",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "greet",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_greeting",
+        "type": "string"
+      }
+    ],
+    "name": "setGreeting",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "_to",
+        "type": "address"
+      }
+    ],
+    "name": "transferTo",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/example/package.json
+++ b/example/package.json
@@ -6,15 +6,20 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "yarn typechain",
+    "typechain": "typechain --target=ethers-v5 abis/*.json --out-dir=types/contracts"
   },
   "dependencies": {
     "@chakra-ui/react": "^1.7.3",
+    "@typechain/ethers-v5": "^8.0.5",
     "@web3-ui/components": "^0.4.1",
     "@web3-ui/core": "^0.4.0",
+    "@web3-ui/hooks": "^0.8.1",
     "next": "12.0.7",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "typechain": "^6.1.0"
   },
   "devDependencies": {
     "eslint": "8.4.1",

--- a/example/pages/index.tsx
+++ b/example/pages/index.tsx
@@ -1,9 +1,18 @@
 import React, { useEffect, useState } from 'react';
-
-import { NFTGallery } from '@web3-ui/components';
-import { Stack, Input, Button, Heading, Text } from '@chakra-ui/react';
+import {
+  Container,
+  Stack,
+  Input,
+  Button,
+  Heading,
+  Text
+} from '@chakra-ui/react';
 import { useWallet, ConnectWallet } from '@web3-ui/core';
-import { Container } from '@chakra-ui/react';
+import { NFTGallery } from '@web3-ui/components';
+import { useContract } from '@web3-ui/hooks';
+import { Greeter } from '../types/contracts';
+import GreeterABI from '../abis/Greeter.json';
+
 export default function Home() {
   const [address, setAddress] = useState('');
   const [nftGallery, setNftGallery] = useState(null);
@@ -13,16 +22,43 @@ export default function Home() {
     connected,
     provider
   } = useWallet();
+  const [greeterContract, isReady] = useContract<Greeter>(
+    // Rinkeby
+    '0x7e1D33FcF1C6b6fd301e0B7305dD40E543CF7135',
+    GreeterABI
+  );
 
   useEffect(() => {
     console.log('correctNetwork', correctNetwork);
   }, [correctNetwork]);
+
+  async function setGreeting() {
+    console.log(greeterContract);
+
+    const response = await greeterContract.setGreeting('Hello World');
+
+    console.log('setGreeting', response);
+  }
+
+  async function greet() {
+    const response = await greeterContract.greet();
+
+    console.log('greet', response);
+  }
 
   return (
     <Container>
       <ConnectWallet />
       {!correctNetwork && (
         <Button onClick={switchToCorrectNetwork}>Switch to Mainnet.</Button>
+      )}
+      {isReady ? (
+        <Stack my={5}>
+          <Button onClick={setGreeting}>Set Greeting</Button>
+          <Button onClick={greet}>Greet</Button>
+        </Stack>
+      ) : (
+        <> </>
       )}
       <Stack p={3}>
         <Heading>Demo</Heading>

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -29,16 +29,13 @@ function MyApp({ Component, pageProps }) {
 
 The following hooks are available:
 
-- [@web3-ui/hooks](#web3-uihooks)
-  - [Getting started](#getting-started)
-  - [Hooks](#hooks)
-    - [useWallet](#usewallet)
-    - [useContract](#usecontract)
-    - [useTransaction](#usetransaction)
-    - [useTokenBalance](#usetokenbalance)
-    - [useReadOnlyContract](#usereadonlycontract)
-    - [useReadOnlyProvider](#usereadonlyprovider)
-    - [usePoller](#usepoller)
+- [useWallet](#usewallet)
+- [useContract](#usecontract)
+- [useTransaction](#usetransaction)
+- [useTokenBalance](#usetokenbalance)
+- [useReadOnlyContract](#usereadonlycontract)
+- [useReadOnlyProvider](#usereadonlyprovider)
+- [usePoller](#usepoller)
 
 ---
 

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -29,10 +29,13 @@ function MyApp({ Component, pageProps }) {
 
 The following hooks are available:
 
-- [useWallet](#usewallet)
-- [useContract](#usecontract)
-- [useTransaction](#usetransaction)
-- [useTokenBalance](#usetokenbalance)
+- [@web3-ui/hooks](#web3-uihooks)
+  - [Getting started](#getting-started)
+  - [Hooks](#hooks)
+    - [useWallet](#usewallet)
+    - [useContract](#usecontract)
+    - [useTransaction](#usetransaction)
+    - [useTokenBalance](#usetokenbalance)
 
 ---
 
@@ -76,9 +79,66 @@ import { useContract } from '@web3-ui/hooks';
 
 const [contract, isReady] = useContract('CONTRACT_ADDRESS', 'CONTRACT_ABI');
 
-//check that the contract has been loaded
+// check that the contract has been loaded
 if (isReady) {
   await contract.greeting();
+}
+```
+
+A generic type argument can be passed down to the hook to create the type definitions based on the ABIs stored in a directory. To auto-generate the types it is highly recommended to use [typechain](https://www.npmjs.com/package/typechain) package.
+
+Install [typechain](https://www.npmjs.com/package/typechain)
+
+```bash
+yarn add typechain --dev # or `npm i -D typechain`
+```
+
+Add a script to your `package.json` file
+
+```json
+"scripts": {
+    "typechain": "typechain --target=ethers-v5 <ABI_DIRECTORY_PATH> --out-dir=<OUTPUT_DIRECTORY_PATH>",
+}
+```
+
+- The `<ABI_DIRECTORY_PATH>` should be the path to where all of the ABIs are stored. e.g. `src/abis/*.json` (This depends on your preferred file structure)
+- The `<OUTPUT_DIRECTORY_PATH>` will be your preferred path to where the generated type definitions should be placed. e.g. `src/types/contracts`
+- For the `<OUTPUT_DIRECTORY_PATH>` it is also recommended to add the directory path on `.gitignore` since these can be generated via `typechain` script
+
+For an actual example check below,
+
+```json
+"scripts": {
+    "typechain": "typechain --target=ethers-v5 src/abis/**/*.json --out-dir=src/types/contracts",
+}
+```
+
+Next is to put all of your ABI JSON files stored to the defined `ABI_DIRECTORY_PATH` directory.
+
+- `src/abis/ERC20Token/ERC20Token.json`
+- `src/abis/CoolProtocol/CoolProtocolLendingPool.json`
+
+Then finally run the script to generate the type definitions.
+
+```bash
+yarn typechain # or `npm run typechain`
+```
+
+Example usage in utilizing the generic type argument for `useContract` hook
+
+```tsx
+import { useContract } from '@web3-ui/hooks';
+import { ERC20Token } from 'types/contracts/ERC20Token';
+import ERC20TokenABI from 'abis/ERC20Token/ERC20Token.json';
+
+const [contract, isReady] = useContract<ERC20Token>(
+  'CONTRACT_ADDRESS',
+  ERC20TokenABI
+);
+
+// check that the contract has been loaded
+if (isReady) {
+  await contract.balanceOf('0x...');
 }
 ```
 

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -93,13 +93,14 @@ A generic type argument can be passed down to the hook to create the type defini
 Install [typechain](https://www.npmjs.com/package/typechain)
 
 ```bash
-yarn add typechain --dev # or `npm i -D typechain`
+yarn add typechain @typechain/ethers-v5 --dev # or `npm i -D typechain`
 ```
 
-Add a script to your `package.json` file
+Add a "typechain" script to your `package.json` file as well as a "postinstall" script that executes the script after installing dependencies.
 
 ```json
 "scripts": {
+    "postinstall": "yarn typechain",
     "typechain": "typechain --target=ethers-v5 <ABI_DIRECTORY_PATH> --out-dir=<OUTPUT_DIRECTORY_PATH>",
 }
 ```
@@ -112,6 +113,7 @@ For an actual example check below,
 
 ```json
 "scripts": {
+    "postinstall": "yarn typechain",
     "typechain": "typechain --target=ethers-v5 src/abis/**/*.json --out-dir=src/types/contracts",
 }
 ```
@@ -130,19 +132,29 @@ yarn typechain # or `npm run typechain`
 Example usage in utilizing the generic type argument for `useContract` hook
 
 ```tsx
+import React from 'react';
 import { useContract } from '@web3-ui/hooks';
 import { ERC20Token } from 'types/contracts/ERC20Token';
 import ERC20TokenABI from 'abis/ERC20Token/ERC20Token.json';
 
-const [contract, isReady] = useContract<ERC20Token>(
-  'CONTRACT_ADDRESS',
-  ERC20TokenABI
-);
+function App() {
+  const [contract, isReady] = useContract<ERC20Token>(
+    'CONTRACT_ADDRESS',
+    ERC20TokenABI
+  );
 
-// check that the contract has been loaded
-if (isReady) {
-  await contract.balanceOf('0x...');
+  async function checkBalance() {
+    const response = await contract.balanceOf('0x...');
+
+    console.log('checkBalance', response);
+  }
+
+  return (
+    <>{isReady ? <button onClick={checkBalance}></button> : 'Connect Wallet'}</>
+  );
 }
+
+export default App;
 ```
 
 ---

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -90,7 +90,7 @@ A generic type argument can be passed down to the hook to create the type defini
 Install [typechain](https://www.npmjs.com/package/typechain)
 
 ```bash
-yarn add typechain @typechain/ethers-v5 --dev # or `npm i -D typechain`
+yarn add typechain @typechain/ethers-v5 --dev # or `npm i -D typechain @typechain/ethers-v5`
 ```
 
 Add a "typechain" script to your `package.json` file as well as a "postinstall" script that executes the script after installing dependencies.

--- a/packages/hooks/src/hooks/useContract.ts
+++ b/packages/hooks/src/hooks/useContract.ts
@@ -1,10 +1,28 @@
 import React from 'react';
 import { Web3Context } from '../Provider';
-import { Contract } from 'ethers';
+import { Contract, ContractInterface } from 'ethers';
 
-export function useContract(address: string, abi) {
+/**
+ * @description
+ * Defines the contract instance on `useState` hook
+ */
+export type ContractInstance<T extends Contract> = T | null | undefined;
+
+/**
+ * @description
+ * The return type of the `useContract` hook
+ */
+export type UseContractHook<T extends Contract> = [
+  T | null | undefined,
+  boolean
+];
+
+export function useContract<T extends Contract>(
+  address: string,
+  abi: ContractInterface
+): UseContractHook<T> {
   const context = React.useContext(Web3Context);
-  const [contract, setContract] = React.useState({});
+  const [contract, setContract] = React.useState<ContractInstance<T>>(null);
   const [isReady, setIsReady] = React.useState(false);
   React.useEffect(() => {
     if (context?.connected) {
@@ -12,16 +30,9 @@ export function useContract(address: string, abi) {
         address,
         abi,
         context.signer || undefined
-      );
-      const contractInterface = Object.values(
-        newContract.interface.functions
-      ).reduce((accumulator, funcFragment) => {
-        return {
-          ...accumulator,
-          [funcFragment.name]: newContract[funcFragment.name]
-        };
-      }, {});
-      setContract(contractInterface);
+      ) as T;
+
+      setContract(newContract);
       setIsReady(true);
     }
   }, [context]);

--- a/packages/hooks/src/hooks/useContract.ts
+++ b/packages/hooks/src/hooks/useContract.ts
@@ -12,7 +12,10 @@ export type ContractInstance<T extends Contract> = T | null;
  * @description
  * The return type of the `useContract` hook
  */
-export type UseContractHook<T extends Contract> = [T | null, boolean];
+export type UseContractHook<T extends Contract> = [
+  ContractInstance<T> | null,
+  boolean
+];
 
 export function useContract<T extends Contract>(
   address: string,

--- a/packages/hooks/src/hooks/useContract.ts
+++ b/packages/hooks/src/hooks/useContract.ts
@@ -6,16 +6,13 @@ import { Contract, ContractInterface } from 'ethers';
  * @description
  * Defines the contract instance on `useState` hook
  */
-export type ContractInstance<T extends Contract> = T | null | undefined;
+export type ContractInstance<T extends Contract> = T | null;
 
 /**
  * @description
  * The return type of the `useContract` hook
  */
-export type UseContractHook<T extends Contract> = [
-  T | null | undefined,
-  boolean
-];
+export type UseContractHook<T extends Contract> = [T | null, boolean];
 
 export function useContract<T extends Contract>(
   address: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4349,6 +4349,14 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@typechain/ethers-v5@^8.0.5":
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/@typechain/ethers-v5/-/ethers-v5-8.0.5.tgz#d469420e9a73deb7fa076cde9edb45d713dd1b8c"
+  integrity sha512-ntpj4cS3v4WlDu+hSKSyj9A3o1tKtWC30RX1gobeYymZColeJiUemC1Kgfa0MWGmInm5CKxoHVhEvYVgPOZn1A==
+  dependencies:
+    lodash "^4.17.15"
+    ts-essentials "^7.0.1"
+
 "@types/aria-query@^4.2.0":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
@@ -4609,7 +4617,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/prettier@^2.0.0":
+"@types/prettier@^2.0.0", "@types/prettier@^2.1.1":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.2.tgz#4c62fae93eb479660c3bd93f9d24d561597a8281"
   integrity sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==
@@ -5500,6 +5508,16 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-back@^3.0.1, array-back@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
+array-back@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.2.tgz#8004e999a6274586beeb27342168652fdb89fa1e"
+  integrity sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==
 
 array-find-index@^1.0.1:
   version "1.0.2"
@@ -6582,7 +6600,7 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -6953,6 +6971,26 @@ comma-separated-tokens@^1.0.0:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
+
+command-line-args@^5.1.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.0.tgz#087b02748272169741f1fd7c785b295df079b9be"
+  integrity sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==
+  dependencies:
+    array-back "^3.1.0"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
+command-line-usage@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-6.1.1.tgz#c908e28686108917758a49f45efb4f02f76bc03f"
+  integrity sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==
+  dependencies:
+    array-back "^4.0.1"
+    chalk "^2.4.2"
+    table-layout "^1.0.1"
+    typical "^5.2.0"
 
 commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
@@ -7530,6 +7568,11 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
+
+deep-extend@~0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.4"
@@ -9123,6 +9166,13 @@ find-cache-dir@^3.3.1:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
+
 find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
@@ -9335,7 +9385,7 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-extra@^7.0.1:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -11296,7 +11346,7 @@ js-sha3@0.5.7:
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
   integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
 
-js-sha3@0.8.0:
+js-sha3@0.8.0, js-sha3@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
   integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
@@ -11797,6 +11847,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -13530,6 +13585,11 @@ prettier@^1.19.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
+prettier@^2.1.2:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
+
 prettier@^2.2.0, prettier@^2.2.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.0.tgz#a6370e2d4594e093270419d9cc47f7670488f893"
@@ -14285,6 +14345,11 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+reduce-flatten@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-2.0.0.tgz#734fd84e65f375d7ca4465c69798c25c9d10ae27"
+  integrity sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==
 
 refractor@^3.1.0:
   version "3.5.0"
@@ -15372,6 +15437,11 @@ string-argv@^0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
+string-format@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string-format/-/string-format-2.0.0.tgz#f2df2e7097440d3b65de31b6d40d54c96eaffb9b"
+  integrity sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==
+
 string-hash@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
@@ -15695,6 +15765,16 @@ synchronous-promise@^2.0.15:
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.15.tgz#07ca1822b9de0001f5ff73595f3d08c4f720eb8e"
   integrity sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==
 
+table-layout@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-1.0.2.tgz#c4038a1853b0136d63365a734b6931cf4fad4a04"
+  integrity sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==
+  dependencies:
+    array-back "^4.0.1"
+    deep-extend "~0.6.0"
+    typical "^5.2.0"
+    wordwrapjs "^4.0.0"
+
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
@@ -15980,6 +16060,16 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
+ts-command-line-args@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ts-command-line-args/-/ts-command-line-args-2.2.0.tgz#655e10451b06c86d318e9467546da4d19b773a55"
+  integrity sha512-RedEejZyhiEAOgBkIVxB4QC/SRYtl98D7b7epWB9e6E+TmK8KstXBu3WdnhGbMHicLkHoG7sCAmu+F+ASzLFHA==
+  dependencies:
+    chalk "^4.1.0"
+    command-line-args "^5.1.1"
+    command-line-usage "^6.1.0"
+    string-format "^2.0.0"
+
 ts-dedent@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
@@ -15989,6 +16079,11 @@ ts-essentials@^2.0.3:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
+
+ts-essentials@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.3.tgz#686fd155a02133eedcc5362dc8b5056cde3e5a38"
+  integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
 
 ts-jest@^26.4.4:
   version "26.5.6"
@@ -16150,6 +16245,22 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
+typechain@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/typechain/-/typechain-6.1.0.tgz#462a35f555accf870689d1ba5698749108d0ce81"
+  integrity sha512-GGfkK0p3fUgz8kYxjSS4nKcWXE0Lo+teHTetghousIK5njbNoYNDlwn91QIyD181L3fVqlTvBE0a/q3AZmjNfw==
+  dependencies:
+    "@types/prettier" "^2.1.1"
+    debug "^4.1.1"
+    fs-extra "^7.0.0"
+    glob "^7.1.6"
+    js-sha3 "^0.8.0"
+    lodash "^4.17.15"
+    mkdirp "^1.0.4"
+    prettier "^2.1.2"
+    ts-command-line-args "^2.2.0"
+    ts-essentials "^7.0.1"
+
 typedarray-to-buffer@3.1.5, typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -16166,6 +16277,16 @@ typescript@^4.1.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
   integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
+
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
+typical@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
+  integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
 uglify-js@^3.1.4:
   version "3.14.3"
@@ -16955,6 +17076,14 @@ wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+
+wordwrapjs@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-4.0.1.tgz#d9790bccfb110a0fc7836b5ebce0937b37a8b98f"
+  integrity sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==
+  dependencies:
+    reduce-flatten "^2.0.0"
+    typical "^5.2.0"
 
 worker-farm@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request!

Please read the following before submitting:
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- Reference the issue you're modifying.
-->

Closes #197 

## Description

Allows to auto-generate TypeScript smart contract type definitions based on the ABIs provided by the user.

Though it can't be generated in runtime but will have to let user do additional step to generate these typings. We can explore some other ideas if anyone has a better approach to this, the way I see how the developer would be generating types is to execute a command from `typechain`, which should be additional dependency for their side... 

1. Given that they only installed this hooks package, and `useContract` is already being imported and used
2. Install `typechain` library by `yarn add typechain --dev` or `npm i -D typechain`
3. Add a script into their `package.json` file, the script can be named anything they prefer but recommend "typechain"
```json
"scripts": {
    "typechain": "typechain --target=ethers-v5 ABI_DIRECTORY --out-dir=OUTPUT_DIRECTORY",
}
```
- The ABI_DIRECTORY will be containing all of the ABIs that they have saved, so as an example they chose to store all ABI in this directory `src/abis/` but it should be defined as `src/abis/**/*.json` in the script. i.e. `typechain --target=ethers-v5 src/abis/**/*.json --out-dir=OUTPUT_DIRECTORY`
- The OUTPUT_DIRECTORY will be the preferred output directory for the developer and it is recommended that it should be on `.gitignore` since these are generated files and it can be generated once again when required, so it's fine to have this ignored. As an example the output directory can be defined as `src/types/contracts` in the script. i.e. `typechain --target=ethers-v5 src/abis/**/*.json --out-dir=src/types/contracts`
```json
"scripts": {
    "typechain": "typechain --target=ethers-v5 src/abis/**/*.json --out-dir=src/types/contracts",
}
```
4. As soon as they have the "typechain" script added, and the ABIs are in place in the directory (i.e. ABI_DIRECTORY) they store it, then finally execute the script to generate these typings
```bash
yarn typechain

# or 

npm run typechain
```

## 📝 Additional Information

I also sort of removed some code from the `useContract` since I just thought it was not necessary anymore given that we'll be utilizing Typechain for auto-generating type definitions on the fly.

**PS:** And at the time I am writing this I still haven't tested it out myself on an example application. This will be on DRAFT. When I tested it out and my assumption was correct on the approach then I will be removing this.