### PR TITLE
added ens lookup to address component. Requires RPC URL.

### DIFF
--- a/.changeset/sharp-pianos-perform.md
+++ b/.changeset/sharp-pianos-perform.md
@@ -1,0 +1,5 @@
+---
+'@web3-ui/components': minor
+---
+
+Added ENS lookup directly to Address component

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -42,7 +42,7 @@ export const Address: React.FC<AddressProps> = ({
   let feedbackTimeOut: ReturnType<typeof setTimeout>;
   let displayAddress: string = value || '';
   let [ens, setEns] = useState<string | null | undefined>(null);
-  const provider = rpcURL
+  const provider: ethers.providers.JsonRpcProvider | null = rpcURL
     ? new ethers.providers.StaticJsonRpcProvider(rpcURL)
     : null;
 
@@ -50,7 +50,7 @@ export const Address: React.FC<AddressProps> = ({
     if (value.includes('.eth') || value === '' || value === 'Not connected')
       return;
 
-    async function provide() {
+    async function fetchEns() {
       if (provider && value) {
         try {
           const ensResponse = await provider?.lookupAddress(value);
@@ -61,7 +61,7 @@ export const Address: React.FC<AddressProps> = ({
         }
       }
     }
-    provide();
+    fetchEns();
   }, [value, provider]);
 
   if (shortened && value) {

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -7,6 +7,7 @@ import {
 } from '@chakra-ui/react';
 import { CopyIcon, CheckIcon } from '@chakra-ui/icons';
 import React, { useState, useEffect } from 'react';
+import { ethers } from 'ethers';
 
 export interface AddressProps {
   /**
@@ -21,6 +22,10 @@ export interface AddressProps {
    * Shorten the address if it does not resolve to an ENS name
    */
   shortened?: boolean;
+  /**
+   * RPC URL for provider, required for ens lookup
+   */
+  rpcURL?: string;
 }
 
 /**
@@ -30,11 +35,34 @@ export const Address: React.FC<AddressProps> = ({
   value,
   copiable = false,
   shortened = false,
+  rpcURL
 }) => {
   const [error, setError] = useState<null | string>(null);
   const [copied, setCopied] = useState<boolean>(false);
   let feedbackTimeOut: ReturnType<typeof setTimeout>;
   let displayAddress: string = value || '';
+  let [ens, setEns] = useState<string | null | undefined>(null);
+  const provider = rpcURL
+    ? new ethers.providers.StaticJsonRpcProvider(rpcURL)
+    : null;
+
+  useEffect(() => {
+    if (value.includes('.eth') || value === '' || value === 'Not connected')
+      return;
+
+    async function provide() {
+      if (provider && value) {
+        try {
+          const ensResponse = await provider?.lookupAddress(value);
+          setEns(ensResponse);
+          return;
+        } catch (error) {
+          return;
+        }
+      }
+    }
+    provide();
+  }, [value, provider]);
 
   if (shortened && value) {
     if (value.includes('.eth') || value === '' || value === 'Not connected') {
@@ -74,7 +102,7 @@ export const Address: React.FC<AddressProps> = ({
         cursor={copiable ? 'pointer' : 'initial'}
         onClick={handleClick}
       >
-        <Text>{displayAddress}</Text>
+        <Text>{ens || displayAddress}</Text>
         {copiable && (
           <Box ml="auto">
             {copied ? (

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -35,13 +35,13 @@ export const Address: React.FC<AddressProps> = ({
   value,
   copiable = false,
   shortened = false,
-  rpcURL
+  rpcURL,
 }) => {
   const [error, setError] = useState<null | string>(null);
   const [copied, setCopied] = useState<boolean>(false);
   let feedbackTimeOut: ReturnType<typeof setTimeout>;
   let displayAddress: string = value || '';
-  let [ens, setEns] = useState<string | null | undefined>(null);
+  const [ens, setEns] = useState<string | null | undefined>(null);
   const provider: ethers.providers.JsonRpcProvider | null = rpcURL
     ? new ethers.providers.StaticJsonRpcProvider(rpcURL)
     : null;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request!

Please read the following before submitting:
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- Reference the issue you're modifying.
-->

Closes #200 

## Description
>Added ENS lookup functionality directly to the address component. Previously it would only check if an ENS name was already provided

## 📝 Additional Information
This current solution requires an RPC and uses `provider.ensLookup()` from ethers to lookup the address. While researching how to implement this properly for looking up multiple addresses i came across this link to a `reverseRecords` [contract](https://github.com/ensdomains/reverse-records) in the [ENS domain docs](https://docs.ens.domains/dapp-developer-guide/resolving-names)

```
const namehash = require('eth-ens-namehash');
const allnames = await ReverseRecords.getNames(['0x123','0x124'])
const validNames = allnames.filter((n) => namehash.normalize(n) === n )
```

So while this is a working solution, my question is should we implement it as is, so there is an option for ens lookup directly from the component? We could also create an ENS hook and an ENS list hook. The former using ethers.provider.ensLookup for single ENS lookups, and the latter, using the `reverseRecords` contract, performing multiple address lookups.

I just want to make sure we have an efficient method for looking up multiple ENS address on a page without making a bunch of unnecessary calls.