### PR TITLE
fix(hooks): add ERC20ABI, ERC721ABI exports

### DIFF
--- a/.changeset/moody-kangaroos-melt.md
+++ b/.changeset/moody-kangaroos-melt.md
@@ -1,0 +1,6 @@
+---
+'@web3-ui/hooks': minor
+'@web3-ui/core': patch
+---
+
+Added `ERC20ABI` as an export of `@web3-ui/hooks` in order to resolve an incorrect import in the `@web3-ui/core` package.

--- a/packages/core/src/components/TokenGate/TokenGate.tsx
+++ b/packages/core/src/components/TokenGate/TokenGate.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { TokenGate as PrivTokenGate } from '@web3-ui/components';
 import { useReadOnlyContract, useWallet } from '@web3-ui/hooks';
-import { ERC20ABI, ERC721ABI } from '@web3-ui/hooks/src/constants';
+import { ERC20ABI, ERC721ABI } from '@web3-ui/hooks';
 import { BigNumber, ethers } from 'ethers';
 
 export interface TokenGateProps {

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -8,4 +8,9 @@ export {
   usePoller
 } from './hooks';
 export { Provider, Web3Context } from './Provider';
-export { NETWORKS, CHAIN_ID_TO_NETWORK, ERC721ABI } from './constants';
+export {
+  NETWORKS,
+  CHAIN_ID_TO_NETWORK,
+  ERC20ABI,
+  ERC721ABI,
+} from './constants';


### PR DESCRIPTION
## Description

This PR resolves a runtime error caused by an incorrect import in `TokenGate.tsx`.

## 📝 Additional Information

Using `@web3-ui/core` caused the following error:

```
Error: Cannot find module '@web3-ui/hooks/src/constants'
```

I believe this is due to the fact that `TokenGate.tsx` was importing `ERC20ABI` using `@web3-ui/hooks/src/constants` which doesn't exist in the final build.

To resolve this, I added `ERC20ABI` as an export from `@web3-ui/hooks` and updated the imports in `TokenGate.tsx`.

<!---
## Screenshot

If your changes are visual, please add a screenshot.
If they're behavioral, consider adding a screen recording of the change.
-->
