### PR TITLE
chore: publish only dist folders

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -25,6 +25,9 @@
     "type": "git",
     "url": "git+https://github.com/Developer-DAO/web3-ui/"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "preconstruct build",
     "format": "prettier --write \"src/**/*.{ts,tsx,json,js,jsx}\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,9 @@
     "type": "git",
     "url": "git+https://github.com/Developer-DAO/web3-ui/"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "preconstruct build",
     "format": "prettier --write \"src/**/*.{ts,tsx,json,js,jsx}\"",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -25,6 +25,9 @@
     "type": "git",
     "url": "git+https://github.com/Developer-DAO/web3-ui/"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "preconstruct build",
     "format": "prettier --write \"src/**/*.{ts,tsx,json,js,jsx}\"",


### PR DESCRIPTION
## Description

Added a `files` key to each package's `package.json` so that only the `dist` folder (and `package.json`, which is always published) is published to `npm`. 

Currently we're publishing all files in each package's directory which is unnecessary.
