### PR TITLE
Refactor `useTransaction` hook's `execute` fn's API

### DIFF
--- a/.changeset/tidy-goats-rule.md
+++ b/.changeset/tidy-goats-rule.md
@@ -1,0 +1,5 @@
+---
+'@web3-ui/hooks': minor
+---
+
+You can now pass in your arguments directly to the execute function in useTransaction.

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -89,9 +89,9 @@ if (isReady) {
 
 ### useTransaction
 
-The `useTransaction` hook takes in a contract function and a list of arguments to pass to it. It returns an array of three elements:
+The `useTransaction` hook takes in a contract function. It returns an array of three elements:
 
-- `execute`: Calling this function will execute the transaction.
+- `execute`: Calling this function will execute the transaction. You should pass your arguments/parameters to this function as an array.
 
 - `loading`: Will be true when the transaction is executing and will be false once the transaction has been confirmed.
 
@@ -101,14 +101,14 @@ The `useTransaction` hook takes in a contract function and a list of arguments t
 import { useTransaction, useContract } from '@web3-ui/hooks';
 
 const greeterContract = useContract('CONTRACT_ADDRESS', 'CONTRACT_ABI');
-const [execute, loading, error] = useTransaction(greeter.setGreeting, [
+const [execute, loading, error] = useTransaction(greeter.setGreeting);
+
+await execute([
   'Hello, world!',
   {
     value: ethers.utils.parseEther('0.1') // you can also use this for payable transactions
   }
-]);
-
-execute(); // will execute the transaction
+]); // will execute the transaction
 ```
 
 ---

--- a/packages/hooks/src/hooks/useTransaction.ts
+++ b/packages/hooks/src/hooks/useTransaction.ts
@@ -3,9 +3,8 @@ import React from 'react';
 /**
  * @dev Hook to get the loading status, error, and data of a function call.
  * @param method The contract function you want to call
- * @param args an array of arguments to pass to the function.
  * @returns {
- *  execute: () => Promise<any>,
+ *  execute: (args: any[]) => Promise<any>,
  *  loading: boolean,
  *  error: null | Error,
  * } {
@@ -15,11 +14,13 @@ import React from 'react';
  * }
  */
 
-export function useTransaction(method, args: any[] = []) {
+export function useTransaction(
+  method
+): [(args: any[]) => Promise<any>, boolean, any] {
   const [loading, setLoading] = React.useState<boolean>(false);
   const [error, setError] = React.useState<any>(null);
 
-  const execute = async () => {
+  const execute = async (args: any[]) => {
     setLoading(true);
     setError(null);
     try {

--- a/packages/hooks/src/stories/UseTransaction.stories.tsx
+++ b/packages/hooks/src/stories/UseTransaction.stories.tsx
@@ -81,9 +81,7 @@ const UsingUseContract = () => {
   };
 
   // @ts-expect-error
-  const [setGreeting, loading, error] = useTransaction(contract.setGreeting, [
-    value
-  ]);
+  const [setGreeting, loading, error] = useTransaction(contract.setGreeting);
 
   if (connected) {
     return (
@@ -99,7 +97,11 @@ const UsingUseContract = () => {
               value={value}
               onChange={e => setValue(e.target.value)}
             />
-            <Button type="submit" isLoading={loading} onClick={setGreeting}>
+            <Button
+              type="submit"
+              isLoading={loading}
+              onClick={() => setGreeting([value])}
+            >
               Set Greeting
             </Button>
             <FormErrorMessage>{error && error.message}</FormErrorMessage>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request!

Please read the following before submitting:
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- Reference the issue you're modifying.
-->

Closes #174 

## Description

This PR changes the API of the `useTransaction` hook. You can now pass in fn args directly to the `execute` function instead of passing them to the `useTransaction` hook.

Old API: 
```tsx
const [execute, loading, error] = useTransaction(greeter.setGreeting, ['Hello, world!',
  {
    value: ethers.utils.parseEther('0.1')
]);

await execute();
```

New API:
```tsx
const [execute, loading, error] = useTransaction(greeter.setGreeting);

await execute(['Hello, world!',
  {
    value: ethers.utils.parseEther('0.1')
  }
]);
```