### PR TITLE
Remove unnecessary text from the top of `NFTGallery`

### DIFF
--- a/.changeset/twelve-tables-sleep.md
+++ b/.changeset/twelve-tables-sleep.md
@@ -1,0 +1,5 @@
+---
+'@web3-ui/components': patch
+---
+
+The unnecessary static heading at the top of the NFTGallery component has been removed.

--- a/packages/components/src/components/NFTGallery/NFTGallery.test.tsx
+++ b/packages/components/src/components/NFTGallery/NFTGallery.test.tsx
@@ -8,8 +8,6 @@ describe('NFTGallery', () => {
     const { container } = render(
       <NFTGallery address="0x1A16c87927570239FECD343ad2654fD81682725e" />
     );
-
-    expect(container).toHaveTextContent('NFT Gallery');
     await waitFor(() => {
       expect(container).toHaveTextContent('MutantApeYachtClub #29501');
       expect(container).toHaveTextContent('Dev #1');
@@ -18,8 +16,6 @@ describe('NFTGallery', () => {
 
   it('renders an error', async () => {
     const { container } = render(<NFTGallery address="bad_address" />);
-
-    expect(container).toHaveTextContent('NFT Gallery');
     await waitFor(() => {
       expect(container).toHaveTextContent('OpenSea request failed');
     });

--- a/packages/components/src/components/NFTGallery/NFTGallery.tsx
+++ b/packages/components/src/components/NFTGallery/NFTGallery.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { ethers } from 'ethers';
-import { VStack, Heading, Grid, Alert, AlertIcon } from '@chakra-ui/react';
+import { VStack, Grid, Alert, AlertIcon } from '@chakra-ui/react';
 import { NFTCard } from '../NFT';
 
 export interface NFTGalleryProps {
@@ -68,7 +68,6 @@ export const NFTGallery = ({
 
   return (
     <VStack>
-      <Heading size="lg">NFT Gallery</Heading>
       {errorMessage && (
         <Alert status="error">
           <AlertIcon />


### PR DESCRIPTION
The unnecessary static heading at the top of the NFTGallery component has been removed.