### PR TITLE
removed RPC, made ENS lookup optional

### DIFF
--- a/.changeset/gold-crabs-begin.md
+++ b/.changeset/gold-crabs-begin.md
@@ -1,0 +1,5 @@
+---
+'@web3-ui/components': minor
+---
+
+Removed RPC Url from address component

--- a/packages/components/src/components/Address/Address.stories.tsx
+++ b/packages/components/src/components/Address/Address.stories.tsx
@@ -15,31 +15,26 @@ export const DefaultShortenedWithProvidedENS = () => (
   <Address shortened value="testaddress.eth" />
 );
 
-export const DefaultShortenedWithENSLookup = () => (
-  <Address shortened value="0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" ens />
-);
-
 export const DefaultShortenedWithHexAddress = () => (
   <Address shortened value="0x7Be8076f4EA4A4AD08075C2508e481d6C946D12b" />
 );
 
 type AddressProps = {
   shortened?: boolean;
+  ens?: boolean;
 };
 
 const AddressUsingProvider = (props: AddressProps) => {
-  const { connected, connectWallet, connection } = useWallet();
+  const { connected, connectWallet, connection, provider } = useWallet();
 
   return (
     <VStack>
       <Address
         copiable
-        value={
-          connected
-            ? connection.ens || connection.userAddress || ''
-            : 'Not connected'
-        }
+        value={connected ? connection.userAddress || '' : 'Not connected'}
         shortened={props.shortened}
+        provider={provider || undefined}
+        ens={props.ens}
       />
       <Button onClick={connectWallet}>Connect wallet</Button>
     </VStack>
@@ -55,6 +50,12 @@ export const WithWallet = () => (
 export const WithWalletShortened = () => (
   <Provider network={NETWORKS.rinkeby}>
     <AddressUsingProvider shortened />
+  </Provider>
+);
+
+export const EnsLookupWithProvider = () => (
+  <Provider network={NETWORKS.rinkeby}>
+    <AddressUsingProvider shortened ens={true} />
   </Provider>
 );
 

--- a/packages/components/src/components/Address/Address.stories.tsx
+++ b/packages/components/src/components/Address/Address.stories.tsx
@@ -11,8 +11,12 @@ export default {
 
 export const Default = () => <Address value="testaddress.eth" />;
 
-export const DefaultShortenedWithENS = () => (
+export const DefaultShortenedWithProvidedENS = () => (
   <Address shortened value="testaddress.eth" />
+);
+
+export const DefaultShortenedWithENSLookup = () => (
+  <Address shortened value="0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" ens />
 );
 
 export const DefaultShortenedWithHexAddress = () => (

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -47,7 +47,7 @@ export const Address: React.FC<AddressProps> = ({
   let feedbackTimeOut: ReturnType<typeof setTimeout>;
   let displayAddress: string = value || '';
   const [ensName, setEnsName] = useState<string | undefined>(undefined);
-  
+
   useEffect(() => {
     if (value) {
       if (value.includes('.eth') || value === '' || value === 'Not connected')

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -47,18 +47,16 @@ export const Address: React.FC<AddressProps> = ({
   let feedbackTimeOut: ReturnType<typeof setTimeout>;
   let displayAddress: string = value || '';
   const [ensName, setEnsName] = useState<string | undefined>(undefined);
-  const rpcProvider: ethers.providers.Web3Provider | undefined = provider
-    ? provider
-    : undefined;
+  
   useEffect(() => {
     if (value) {
       if (value.includes('.eth') || value === '' || value === 'Not connected')
         return;
     }
     async function fetchEns() {
-      if (ens && value && rpcProvider) {
+      if (ens && value && provider) {
         try {
-          const ensResponse = await rpcProvider?.lookupAddress(value);
+          const ensResponse = await provider?.lookupAddress(value);
           setEnsName(ensResponse || undefined);
           return;
         } catch (error) {
@@ -67,7 +65,7 @@ export const Address: React.FC<AddressProps> = ({
       }
     }
     fetchEns();
-  }, [value, rpcProvider]);
+  }, [value, provider]);
 
   if (shortened && value) {
     if (value.includes('.eth') || value === '' || value === 'Not connected') {

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -42,25 +42,24 @@ export const Address: React.FC<AddressProps> = ({
   shortened = false,
   ens = false,
 }) => {
-  const [error, setError] = useState<null | string>(null);
+  const [error, setError] = useState<undefined | string>(undefined);
   const [copied, setCopied] = useState<boolean>(false);
   let feedbackTimeOut: ReturnType<typeof setTimeout>;
   let displayAddress: string = value || '';
-  const [ensName, setEnsName] = useState<string | null>(null);
-  const rpcProvider: ethers.providers.Web3Provider | null = provider
+  const [ensName, setEnsName] = useState<string | undefined>(undefined);
+  const rpcProvider: ethers.providers.Web3Provider | undefined = provider
     ? provider
-    : null;
+    : undefined;
   useEffect(() => {
     if (value) {
       if (value.includes('.eth') || value === '' || value === 'Not connected')
         return;
-      return;
     }
     async function fetchEns() {
       if (ens && value && rpcProvider) {
         try {
           const ensResponse = await rpcProvider?.lookupAddress(value);
-          setEnsName(ensResponse || null);
+          setEnsName(ensResponse || undefined);
           return;
         } catch (error) {
           return;
@@ -84,7 +83,7 @@ export const Address: React.FC<AddressProps> = ({
     if (copiable && value) {
       try {
         await navigator.clipboard.writeText(value);
-        setError(null);
+        setError(undefined);
         setCopied(true);
 
         feedbackTimeOut = setTimeout(() => {

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -17,7 +17,7 @@ export interface AddressProps {
   /**
    * Provider, required for ENS lookup
    */
-  provider: ethers.providers.Web3Provider;
+  provider?: ethers.providers.Web3Provider;
   /**
    * Whether the address can be copied or not
    */

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -17,7 +17,7 @@ export interface AddressProps {
   /**
    * Provider, required for ENS lookup
    */
-  provider?: ethers.providers.Web3Provider;
+  provider: ethers.providers.Web3Provider;
   /**
    * Whether the address can be copied or not
    */
@@ -47,19 +47,19 @@ export const Address: React.FC<AddressProps> = ({
   let feedbackTimeOut: ReturnType<typeof setTimeout>;
   let displayAddress: string = value || '';
   const [ensName, setEnsName] = useState<string | null>(null);
-  const provider: ethers.providers.Web3Provider | null = provider
+  const rpcProvider: ethers.providers.Web3Provider | null = provider
+    ? provider
     : null;
   useEffect(() => {
-    
     if (value) {
       if (value.includes('.eth') || value === '' || value === 'Not connected')
         return;
+      return;
     }
-
     async function fetchEns() {
-      if (ens && value && provider) {
+      if (ens && value && rpcProvider) {
         try {
-          const ensResponse = await provider?.lookupAddress(value);
+          const ensResponse = await rpcProvider?.lookupAddress(value);
           setEnsName(ensResponse || null);
           return;
         } catch (error) {
@@ -68,7 +68,7 @@ export const Address: React.FC<AddressProps> = ({
       }
     }
     fetchEns();
-  }, [value, provider]);
+  }, [value, rpcProvider]);
 
   if (shortened && value) {
     if (value.includes('.eth') || value === '' || value === 'Not connected') {

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -23,9 +23,9 @@ export interface AddressProps {
    */
   shortened?: boolean;
   /**
-   * RPC URL for provider, required for ens lookup
+   * Set to true for ENS lookup
    */
-  rpcURL?: string;
+  ens?: boolean;
 }
 
 /**
@@ -35,26 +35,26 @@ export const Address: React.FC<AddressProps> = ({
   value,
   copiable = false,
   shortened = false,
-  rpcURL,
+  ens = false,
 }) => {
   const [error, setError] = useState<null | string>(null);
   const [copied, setCopied] = useState<boolean>(false);
   let feedbackTimeOut: ReturnType<typeof setTimeout>;
   let displayAddress: string = value || '';
-  const [ens, setEns] = useState<string | null | undefined>(null);
-  const provider: ethers.providers.JsonRpcProvider | null = rpcURL
-    ? new ethers.providers.StaticJsonRpcProvider(rpcURL)
-    : null;
-
+  const [ensName, setEnsName] = useState<string | null | undefined>(null);
+  const provider: ethers.providers.JsonRpcProvider =
+    new ethers.providers.Web3Provider(window.ethereum, 'any');
   useEffect(() => {
     if (value.includes('.eth') || value === '' || value === 'Not connected')
       return;
 
     async function fetchEns() {
-      if (provider && value) {
+      console.log(ens, value);
+
+      if (ens == true && value) {
         try {
           const ensResponse = await provider?.lookupAddress(value);
-          setEns(ensResponse);
+          setEnsName(ensResponse);
           return;
         } catch (error) {
           return;
@@ -62,7 +62,7 @@ export const Address: React.FC<AddressProps> = ({
       }
     }
     fetchEns();
-  }, [value, provider]);
+  }, [value]);
 
   if (shortened && value) {
     if (value.includes('.eth') || value === '' || value === 'Not connected') {
@@ -102,7 +102,7 @@ export const Address: React.FC<AddressProps> = ({
         cursor={copiable ? 'pointer' : 'initial'}
         onClick={handleClick}
       >
-        <Text>{ens || displayAddress}</Text>
+        <Text>{ensName || displayAddress}</Text>
         {copiable && (
           <Box ml="auto">
             {copied ? (

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -41,7 +41,7 @@ export const Address: React.FC<AddressProps> = ({
   const [copied, setCopied] = useState<boolean>(false);
   let feedbackTimeOut: ReturnType<typeof setTimeout>;
   let displayAddress: string = value || '';
-  const [ensName, setEnsName] = useState<string | null | undefined>(null);
+  const [ensName, setEnsName] = useState<string | null>(null);
   const provider: ethers.providers.JsonRpcProvider =
     new ethers.providers.Web3Provider(window.ethereum, 'any');
   useEffect(() => {
@@ -49,9 +49,9 @@ export const Address: React.FC<AddressProps> = ({
       return;
 
     async function fetchEns() {
-      if (ens == true && value) {
+      if (ens && value) {
         try {
-          const ensResponse = await provider?.lookupAddress(value);
+          const ensResponse = await provider.lookupAddress(value);
           setEnsName(ensResponse);
           return;
         } catch (error) {

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -15,6 +15,10 @@ export interface AddressProps {
    */
   value: string;
   /**
+   * Provider, required for ENS lookup
+   */
+  provider?: ethers.providers.Web3Provider;
+  /**
    * Whether the address can be copied or not
    */
   copiable?: boolean;
@@ -33,6 +37,7 @@ export interface AddressProps {
  */
 export const Address: React.FC<AddressProps> = ({
   value,
+  provider,
   copiable = false,
   shortened = false,
   ens = false,
@@ -42,12 +47,14 @@ export const Address: React.FC<AddressProps> = ({
   let feedbackTimeOut: ReturnType<typeof setTimeout>;
   let displayAddress: string = value || '';
   const [ensName, setEnsName] = useState<string | null>(null);
-  const provider: ethers.providers.Web3Provider | null = window.ethereum
-    ? new ethers.providers.Web3Provider(window.ethereum, 'any')
+  const provider: ethers.providers.Web3Provider | null = provider
     : null;
   useEffect(() => {
-    if (value.includes('.eth') || value === '' || value === 'Not connected')
-      return;
+    
+    if (value) {
+      if (value.includes('.eth') || value === '' || value === 'Not connected')
+        return;
+    }
 
     async function fetchEns() {
       if (ens && value && provider) {

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -42,17 +42,18 @@ export const Address: React.FC<AddressProps> = ({
   let feedbackTimeOut: ReturnType<typeof setTimeout>;
   let displayAddress: string = value || '';
   const [ensName, setEnsName] = useState<string | null>(null);
-  const provider: ethers.providers.JsonRpcProvider =
-    new ethers.providers.Web3Provider(window.ethereum, 'any');
+  const provider: ethers.providers.Web3Provider | null = window.ethereum
+    ? new ethers.providers.Web3Provider(window.ethereum, 'any')
+    : null;
   useEffect(() => {
     if (value.includes('.eth') || value === '' || value === 'Not connected')
       return;
 
     async function fetchEns() {
-      if (ens && value) {
+      if (ens && value && provider) {
         try {
-          const ensResponse = await provider.lookupAddress(value);
-          setEnsName(ensResponse);
+          const ensResponse = await provider?.lookupAddress(value);
+          setEnsName(ensResponse || null);
           return;
         } catch (error) {
           return;
@@ -60,7 +61,7 @@ export const Address: React.FC<AddressProps> = ({
       }
     }
     fetchEns();
-  }, [value]);
+  }, [value, provider]);
 
   if (shortened && value) {
     if (value.includes('.eth') || value === '' || value === 'Not connected') {

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -49,8 +49,6 @@ export const Address: React.FC<AddressProps> = ({
       return;
 
     async function fetchEns() {
-      console.log(ens, value);
-
       if (ens == true && value) {
         try {
           const ensResponse = await provider?.lookupAddress(value);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request!

Please read the following before submitting:
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- Reference the issue you're modifying.
-->

Closes #211 

## Description
Removed the need for an RPC URL
> Switched the need for RPC url by using window.ethereum instead
## 📝 Additional Information
This allows for the optional lookup of ENS names using a provider. It is optional because developers don't need to lookup ENS names in the component if they provide `connection.ens` and this lookup should not be used for looking up a high number of ENS names.


> For looking up many ENS names a contract called [reverseRecords](https://github.com/ensdomains/reverse-records) should be used and the names then provided to the address component.

