### PR TITLE
Documentation - Update  examples to use <Provider> correctly

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -13,12 +13,11 @@ At the root of your React app, wrap your app in the `<Provider>` component:
 ```tsx
 // _app.tsx (or the root of your app)
 import { Provider } from '@web3-ui/components';
-import { NETWORK } from '@web3-ui/core';
 
 // Passing in a theme is optional
 function MyApp({ Component, pageProps }) {
   return (
-    <Provider theme={yourChakraTheme} network={NETWORKS.mainnet}>
+    <Provider theme={yourChakraTheme}>
       <Component {...pageProps} />
     </Provider>
   );

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -13,11 +13,12 @@ At the root of your React app, wrap your app in the `<Provider>` component:
 ```tsx
 // _app.tsx (or the root of your app)
 import { Provider } from '@web3-ui/components';
+import { NETWORK } from '@web3-ui/core';
 
 // Passing in a theme is optional
 function MyApp({ Component, pageProps }) {
   return (
-    <Provider theme={yourChakraTheme}>
+    <Provider theme={yourChakraTheme} network={NETWORKS.mainnet}>
       <Component {...pageProps} />
     </Provider>
   );

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -12,11 +12,11 @@ At the root of your React app, wrap your app in the <Provider> component:
 
 ```tsx
 // _app.tsx (or the root of your app)
-import { Provider } from '@web3-ui/hooks';
+import { Provider, NETWORKS } from '@web3-ui/hooks';
 
 function MyApp({ Component, pageProps }) {
   return (
-    <Provider>
+    <Provider network={NETWORKS.mainnet}>
       <Component {...pageProps} />
     </Provider>
   );


### PR DESCRIPTION
## Description

FIx uses of the `Provider` component in readmes

`<Provider>...` becomes `<Provider network={NETWORKS.mainnet}>`
