### PR TITLE
Add testnet support to NFT and NFTGallery

### DIFF
--- a/.changeset/tidy-dancers-draw.md
+++ b/.changeset/tidy-dancers-draw.md
@@ -1,0 +1,19 @@
+---
+'@web3-ui/components': minor
+---
+
+The NFT and NFTGallery components now support testnets (rinkeby only for now)! You can pass in `isTestnet` to the components if you want to fetch the NFT data from the testnet API. 🎉
+
+```tsx
+<NFT
+  contractAddress="0xd067fae3311a5daefe21b81ec17224c7b2652ca6"
+  tokenId="20"
+  isTestnet
+/>
+
+<NFTGallery
+  address="0x0ED6Cec17F860fb54E21D154b49DAEFd9Ca04106"
+  gridWidth={2}
+  isTestnet
+/>
+```

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -67,7 +67,7 @@ You need to pass in a `provider` prop if you want to use ENS names.
 
 ### NFT
 
-The NFT component takes in the contract address and the token ID of an NFT and displays it as a card.
+The NFT component takes in the contract address and the token ID of an NFT and displays it as a card. You can also pass in `isTestnet` to fetch the NFT data from the testnet API (only Rinkeby for now).
 
 ```tsx
 <NFT contractAddress="0xxxxx0x0x0x0x0x" tokenId={30} size="md" />
@@ -79,7 +79,7 @@ The `size` prop is optional.
 
 ### NFTGallery
 
-The NFTGallery component renders a grid of all the NFTs owned by an account. It accepts ENS names too.
+The NFTGallery component renders a grid of all the NFTs owned by an account. It accepts ENS names too. You can also pass in `isTestnet` to fetch the NFT data from the testnet API (only Rinkeby for now).
 
 ```tsx
 <NFTGallery address="vitalik.eth" web3Provider={provider} gridWidth={4} />

--- a/packages/components/src/components/NFT/NFT.stories.tsx
+++ b/packages/components/src/components/NFT/NFT.stories.tsx
@@ -42,4 +42,12 @@ export const Big = () => (
   />
 );
 
+export const Rinkeby = () => (
+  <NFT
+    contractAddress="0xd067fae3311a5daefe21b81ec17224c7b2652ca6"
+    tokenId="20"
+    isTestnet
+  />
+);
+
 export const Error = () => <NFT contractAddress="abcd" tokenId="1" />;

--- a/packages/components/src/components/NFTGallery/NFTGallery.stories.tsx
+++ b/packages/components/src/components/NFTGallery/NFTGallery.stories.tsx
@@ -36,4 +36,12 @@ nftsOwnedByAnENS.parameters = {
   chromatic: { disableSnapshot: true },
 };
 
+export const rinkeby = () => (
+  <NFTGallery
+    address="0x0ED6Cec17F860fb54E21D154b49DAEFd9Ca04106"
+    gridWidth={2}
+    isTestnet
+  />
+);
+
 export const WithAnError = () => <NFTGallery address="bad_address" />;

--- a/packages/components/src/components/NFTGallery/NFTGallery.tsx
+++ b/packages/components/src/components/NFTGallery/NFTGallery.tsx
@@ -17,6 +17,10 @@ export interface NFTGalleryProps {
    * A Web3Provider. Only needed if the address will be an ENS name.
    */
   web3Provider?: ethers.providers.Web3Provider;
+  /**
+   * Use testnet api instead of mainnet
+   */
+  isTestnet?: boolean;
 }
 
 export interface OpenSeaAsset {
@@ -38,6 +42,7 @@ export const NFTGallery = ({
   address,
   gridWidth = 4,
   web3Provider,
+  isTestnet = false,
 }: NFTGalleryProps) => {
   const [nfts, setNfts] = React.useState<OpenSeaAsset[]>([]);
   const [errorMessage, setErrorMessage] = React.useState(null);
@@ -45,13 +50,20 @@ export const NFTGallery = ({
   useEffect(() => {
     async function exec() {
       let resolvedAddress: string | null = address;
+      const apiSubDomain = isTestnet ? `rinkeby-api` : `api`;
+      if (isTestnet)
+        console.log(
+          `⚠️ OpenSea currently only supports Rinkedby with testnets.`
+        );
       if (address.endsWith('.eth')) {
         if (!web3Provider) {
           return console.error('Please provide a web3 provider');
         }
         resolvedAddress = await web3Provider.resolveName(address);
       }
-      fetch(`https://api.opensea.io/api/v1/assets?owner=${resolvedAddress}`)
+      fetch(
+        `https://${apiSubDomain}.opensea.io/api/v1/assets?owner=${resolvedAddress}`
+      )
         .then((res) => {
           if (!res.ok) {
             throw Error(
@@ -89,6 +101,7 @@ export const NFTGallery = ({
               assetContractSymbol: nft.asset_contract.symbol,
             }}
             size="xs"
+            hideIfError
           />
         ))}
       </Grid>


### PR DESCRIPTION
Closes #243 

- Added a new prop `isTestnet` to `NFT` and `NFTGallery`. If `isTestnet` is `true`, the NFT data will be fetched from the testnet opensea API instead of mainnet. Only Rinkeby is supported for now.