### PR TITLE
Relax network attribute for Provider component

### DIFF
--- a/.changeset/curvy-news-juggle.md
+++ b/.changeset/curvy-news-juggle.md
@@ -1,0 +1,6 @@
+---
+'@web3-ui/core': minor
+'@web3-ui/hooks': minor
+---
+
+Relaxed network attribute

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -18,7 +18,7 @@ import { NETWORK } from '@web3-ui/core';
 // Passing in a theme is optional
 function MyApp({ Component, pageProps }) {
   return (
-    <Provider theme={yourChakraTheme} network={NETWORKS.mainnet}>
+    <Provider theme={yourChakraTheme}>
       <Component {...pageProps} />
     </Provider>
   );

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -13,7 +13,6 @@ At the root of your React app, wrap your app in the `<Provider>` component:
 ```tsx
 // _app.tsx (or the root of your app)
 import { Provider } from '@web3-ui/components';
-import { NETWORK } from '@web3-ui/core';
 
 // Passing in a theme is optional
 function MyApp({ Component, pageProps }) {

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -13,11 +13,12 @@ At the root of your React app, wrap your app in the `<Provider>` component:
 ```tsx
 // _app.tsx (or the root of your app)
 import { Provider } from '@web3-ui/components';
+import { NETWORK } from '@web3-ui/core';
 
 // Passing in a theme is optional
 function MyApp({ Component, pageProps }) {
   return (
-    <Provider theme={yourChakraTheme}>
+    <Provider theme={yourChakraTheme} network={NETWORKS.mainnet}>
       <Component {...pageProps} />
     </Provider>
   );

--- a/packages/core/src/components/Provider/Provider.tsx
+++ b/packages/core/src/components/Provider/Provider.tsx
@@ -4,7 +4,7 @@ import { Provider as ComponentsProvider } from '@web3-ui/components';
 
 interface ProviderProps {
   children: React.ReactNode;
-  network: number;
+  network?: number;
   rpcUrl?: string;
 }
 

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -12,11 +12,11 @@ At the root of your React app, wrap your app in the <Provider> component:
 
 ```tsx
 // _app.tsx (or the root of your app)
-import { Provider } from '@web3-ui/hooks';
+import { Provider, NETWORKS } from '@web3-ui/hooks';
 
 function MyApp({ Component, pageProps }) {
   return (
-    <Provider>
+    <Provider network={NETWORKS.mainnet}>
       <Component {...pageProps} />
     </Provider>
   );

--- a/packages/hooks/src/Provider.tsx
+++ b/packages/hooks/src/Provider.tsx
@@ -15,7 +15,7 @@ export interface Web3ContextType {
   connected: boolean;
   provider?: ethers.providers.Web3Provider | null;
   correctNetwork: boolean;
-  network: number;
+  network?: number;
   readOnlyProvider?: StaticJsonRpcProvider;
 }
 
@@ -29,7 +29,7 @@ export interface ProviderProps {
    * @example NETWORKS.mainnet
    * @type string
    */
-  network: number;
+  network?: number;
   /**
    * @dev Your Infura project ID. This is required if you want to support WalletConnect.
    * @type string


### PR DESCRIPTION
## Description

This pr simply relaxes the type constraint for the network prop on the `Provider` component.

Although the type currently says that it is a required prop it is not in actually and simply a different but valid configuration of this component. 

## 📝 Additional Information

Rendering a provider like this `<Provider></Provider>` results in having the network inferred from the wallet, which is afaik a totally valid use-case.