### PR TITLE
fix: make vitejs example package private

### DIFF
--- a/examples/vitejs/package.json
+++ b/examples/vitejs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vitejs",
   "version": "0.0.0",
+  "private": true,
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request!

Please read the following before submitting:
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- Reference the issue you're modifying.
-->

Closes #278

## Description

This PR prevents `examples/vitejs` from being included in `publish:npm` by setting `"private": true` in its `package.json`.