### PR TITLE
Fix checks for prs from forked repositories

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Build
         run: yarn build
   chromatic-deployment:
+    if: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
     runs-on: ubuntu-latest
     # Job steps
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         run: yarn build
       - name: Publish to Chromatic
         uses: chromaui/action@v1
-        if: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        if: ${{ env.projectToken }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,16 +31,9 @@ jobs:
         run: yarn test
       - name: Build
         run: yarn build
-  chromatic-deployment:
-    if: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-    runs-on: ubuntu-latest
-    # Job steps
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install dependencies
-        run: yarn
       - name: Publish to Chromatic
         uses: chromaui/action@v1
+        if: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,8 @@ jobs:
         run: yarn build
       - name: Publish to Chromatic
         uses: chromaui/action@v1
+        # don't run this step if project token secret not specified
+        # to prevent this workflow failing for any forked repositories
         if: ${{ env.projectToken }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #282

## Description

- [x] Simplify github action (two jobs become one job) - saves time because of skipping unnecessary install steps
- [x] Only run "publish to chromatic" if secret is defined
