### PR TITLE
fix: Handle connection error and expose in useWallet

### DIFF
--- a/.changeset/metal-pets-remain.md
+++ b/.changeset/metal-pets-remain.md
@@ -1,0 +1,5 @@
+---
+'@web3-ui/hooks': minor
+---
+
+Catch errors in connectWallet and expose them, correct type for connectWallet

--- a/packages/hooks/src/Provider.tsx
+++ b/packages/hooks/src/Provider.tsx
@@ -1,7 +1,7 @@
 import { JsonRpcSigner } from '@ethersproject/providers/src.ts/json-rpc-provider';
 import WalletConnectProvider from '@walletconnect/web3-provider';
 import { ethers } from 'ethers';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useMemo, useState } from 'react';
 import Web3Modal, { IProviderOptions } from 'web3modal';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { useReadOnlyProvider } from './hooks';
@@ -20,7 +20,7 @@ export interface Web3ContextType {
   readOnlyProvider?: StaticJsonRpcProvider;
 }
 
-export const Web3Context = React.createContext<Web3ContextType | undefined>(
+export const Web3Context = createContext<Web3ContextType | undefined>(
   undefined
 );
 
@@ -159,14 +159,14 @@ export const Provider: React.FC<ProviderProps> = ({
     }
   }, [network, correctNetwork, infuraId, extraWalletProviders]);
 
-  const disconnectWallet = React.useCallback(() => {
+  const disconnectWallet = useCallback(() => {
     web3Modal?.clearCachedProvider();
     setSigner(null);
     setUserAddress(null);
     setConnected(false);
   }, [web3Modal]);
 
-  const value = React.useMemo(
+  const value = useMemo(
     () => ({
       connectWallet,
       signer,

--- a/packages/hooks/src/Provider.tsx
+++ b/packages/hooks/src/Provider.tsx
@@ -1,16 +1,17 @@
 import { JsonRpcSigner } from '@ethersproject/providers/src.ts/json-rpc-provider';
 import WalletConnectProvider from '@walletconnect/web3-provider';
 import { ethers } from 'ethers';
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import Web3Modal, { IProviderOptions } from 'web3modal';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { useReadOnlyProvider } from './hooks';
 
 export interface Web3ContextType {
-  connectWallet?: () => void;
+  connectWallet?: () => Promise<void>;
   signer?: JsonRpcSigner | null;
   userAddress?: string | null;
   disconnectWallet?: () => void;
+  error?: string;
   chainId?: number | null;
   connected: boolean;
   provider?: ethers.providers.Web3Provider | null;
@@ -68,71 +69,43 @@ export const Provider: React.FC<ProviderProps> = ({
   extraWalletProviders = [],
   rpcUrl = '',
 }) => {
-  const [signer, setSigner] = React.useState<null | JsonRpcSigner>();
+  const [web3Modal, setWeb3Modal] = useState<Web3Modal>();
+  const [signer, setSigner] = useState<null | JsonRpcSigner>();
+  const [error, setError] = useState<string>();
   const [provider, setProvider] =
-    React.useState<ethers.providers.Web3Provider | null>();
-  const [userAddress, setUserAddress] = React.useState<null | string>();
-  const [web3Modal, setWeb3Modal] = React.useState<Web3Modal>();
-  const [chainId, setChainId] = React.useState<number | null>();
-  const [connected, setConnected] = React.useState<boolean>(false);
-  const [correctNetwork, setCorrectNetwork] = React.useState<boolean>(true);
+    useState<ethers.providers.Web3Provider | null>();
+  const [userAddress, setUserAddress] = useState<null | string>();
+  const [chainId, setChainId] = useState<number | null>();
+  const [connected, setConnected] = useState<boolean>(false);
+  const [correctNetwork, setCorrectNetwork] = useState<boolean>(true);
   const readOnlyProvider = useReadOnlyProvider(rpcUrl);
 
-  const connectWallet = React.useCallback(async () => {
-    const defaulProviderOptions = {
-      walletconnect: {
-        package: WalletConnectProvider,
-        options: {
-          bridge: 'https://polygon.bridge.walletconnect.org',
-          infuraId,
-          rpc: {
-            1: `https://mainnet.infura.io/v3/${infuraId}`, // mainnet // For more WalletConnect providers: https://docs.walletconnect.org/quick-start/dapps/web3-provider#required
-            4: `https://rinkeby.infura.io/v3/${infuraId}`,
-            42: `https://kovan.infura.io/v3/${infuraId}`,
-            100: 'https://dai.poa.network', // xDai
-          },
+  const defaulProviderOptions = {
+    walletconnect: {
+      package: WalletConnectProvider,
+      options: {
+        bridge: 'https://polygon.bridge.walletconnect.org',
+        infuraId,
+        rpc: {
+          1: `https://mainnet.infura.io/v3/${infuraId}`, // mainnet // For more WalletConnect providers: https://docs.walletconnect.org/quick-start/dapps/web3-provider#required
+          4: `https://rinkeby.infura.io/v3/${infuraId}`,
+          42: `https://kovan.infura.io/v3/${infuraId}`,
+          100: 'https://dai.poa.network', // xDai
         },
       },
-    };
-    const web3Modal = new Web3Modal({
-      providerOptions: Object.assign(
-        defaulProviderOptions,
-        ...extraWalletProviders
-      ),
-    });
-    setWeb3Modal(web3Modal);
-    const connection = await web3Modal.connect();
-    const provider = new ethers.providers.Web3Provider(connection);
-    setProvider(provider);
-    const chainId = await provider
-      .getNetwork()
-      .then((network) => network.chainId);
-    setChainId(chainId);
-    setCorrectNetwork(chainId === network);
-    const signer = provider.getSigner();
-    setSigner(signer);
-    setUserAddress(await signer.getAddress());
-    setConnected(true);
+    },
+  };
 
-    connection.on('chainChanged', async (newChainId: string) => {
-      const formattedChainId = +newChainId.split('0x')[1];
-      setChainId(formattedChainId);
-      setCorrectNetwork(formattedChainId === network);
-      const provider = new ethers.providers.Web3Provider(connection);
-      setProvider(provider);
-      const signer = provider.getSigner();
-      setSigner(signer);
-      setUserAddress(await signer.getAddress());
-      setConnected(true);
-    });
-
-    connection.on('accountsChanged', async (accounts: string[]) => {
-      if (accounts.length === 0) {
-        // The user has disconnected their account from Metamask
-        web3Modal?.clearCachedProvider();
-        disconnectWallet();
-        return;
-      }
+  const connectWallet = useCallback(async () => {
+    try {
+      const web3Modal = new Web3Modal({
+        providerOptions: Object.assign(
+          defaulProviderOptions,
+          ...extraWalletProviders
+        ),
+      });
+      setWeb3Modal(web3Modal);
+      const connection = await web3Modal.connect();
       const provider = new ethers.providers.Web3Provider(connection);
       setProvider(provider);
       const chainId = await provider
@@ -144,21 +117,47 @@ export const Provider: React.FC<ProviderProps> = ({
       setSigner(signer);
       setUserAddress(await signer.getAddress());
       setConnected(true);
-    });
 
-    connection.on('disconnect', async () => {
-      web3Modal?.clearCachedProvider();
-      disconnectWallet();
-    });
-  }, [
-    Web3Modal,
-    web3Modal,
-    WalletConnectProvider,
-    network,
-    infuraId,
-    ethers,
-    correctNetwork,
-  ]);
+      connection.on('chainChanged', async (newChainId: string) => {
+        const formattedChainId = +newChainId.split('0x')[1];
+        setChainId(formattedChainId);
+        setCorrectNetwork(formattedChainId === network);
+        const provider = new ethers.providers.Web3Provider(connection);
+        setProvider(provider);
+        const signer = provider.getSigner();
+        setSigner(signer);
+        setUserAddress(await signer.getAddress());
+        setConnected(true);
+      });
+
+      connection.on('accountsChanged', async (accounts: string[]) => {
+        if (accounts.length === 0) {
+          // The user has disconnected their account from Metamask
+          web3Modal?.clearCachedProvider();
+          disconnectWallet();
+          return;
+        }
+        const provider = new ethers.providers.Web3Provider(connection);
+        setProvider(provider);
+        const chainId = await provider
+          .getNetwork()
+          .then((network) => network.chainId);
+        setChainId(chainId);
+        setCorrectNetwork(chainId === network);
+        const signer = provider.getSigner();
+        setSigner(signer);
+        setUserAddress(await signer.getAddress());
+        setConnected(true);
+      });
+
+      connection.on('disconnect', async () => {
+        web3Modal?.clearCachedProvider();
+        disconnectWallet();
+      });
+    } catch (err: any) {
+      setError(err?.message || err.toString());
+    }
+  }, [network, correctNetwork, infuraId, extraWalletProviders]);
 
   const disconnectWallet = React.useCallback(() => {
     web3Modal?.clearCachedProvider();
@@ -174,6 +173,7 @@ export const Provider: React.FC<ProviderProps> = ({
       userAddress,
       disconnectWallet,
       connected,
+      error,
       provider,
       network,
       chainId,
@@ -184,6 +184,7 @@ export const Provider: React.FC<ProviderProps> = ({
       connectWallet,
       signer,
       userAddress,
+      error,
       web3Modal,
       connected,
       provider,

--- a/packages/hooks/src/hooks/useWallet.ts
+++ b/packages/hooks/src/hooks/useWallet.ts
@@ -18,6 +18,7 @@ export function useWallet() {
     disconnectWallet,
     userAddress,
     chainId,
+    error,
     signer,
     connected,
     provider,
@@ -76,6 +77,7 @@ export function useWallet() {
   return {
     connectWallet,
     disconnectWallet,
+    error,
     connection: {
       userAddress,
       network: CHAIN_ID_TO_NETWORK[chainId as number],

--- a/packages/hooks/src/hooks/useWallet.ts
+++ b/packages/hooks/src/hooks/useWallet.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { CHAIN_ID_TO_NETWORK, NETWORKS } from '..';
 import { Web3Context } from '../Provider';
 
@@ -6,8 +6,8 @@ import { Web3Context } from '../Provider';
  * @dev Hook to get the current web3 context including information about the connection and other helper methods.
  */
 export function useWallet() {
-  const context = React.useContext(Web3Context);
-  const [ens, setEns] = React.useState<string>();
+  const context = useContext(Web3Context);
+  const [ens, setEns] = useState<string>();
 
   if (!context) {
     throw new Error('No Web3Context found');
@@ -27,7 +27,7 @@ export function useWallet() {
     readOnlyProvider,
   } = context;
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (userAddress && provider && chainId === NETWORKS.mainnet) {
       provider.lookupAddress(userAddress).then((address) => {
         setEns(address as string);


### PR DESCRIPTION
Closes #277 

## Description

- This handles exceptions thrown in `connectWallet` and exposes them as a provider value, and again as a value returned by `useWallet`
- As I was making this update I also made use of destructuring react imports - as it seems like good practice and seems to be consistent with the rest of the codebase.

## 📝 Additional Information

Here's a little loom for convenience, explaining this in a bit more detail :pray:
https://www.loom.com/share/bc25f2154356452789bcaa6354f80fde?from_recorder=1&focus_title=1
