### PR TITLE
Move `ethers` to peer dependencies

### DIFF
--- a/.changeset/khaki-cobras-laugh.md
+++ b/.changeset/khaki-cobras-laugh.md
@@ -1,0 +1,9 @@
+---
+'@web3-ui/components': minor
+'@web3-ui/hooks': minor
+---
+
+!! BREAKING CHANGE !!
+`ethers` has been moved to peer dependencies for both the `components` and `hooks` packages. (It was already a peer dependency for `core`)
+
+This means that you will users will now have to install `ethers` along side our packages manually.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # web3-ui
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-29-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 _In Development 🏗️_
@@ -19,7 +21,7 @@ A library of UI components specifically crafted for web3 use cases.
 1. Install the package
 
 ```bash
-$ yarn add @web3-ui/core
+$ yarn add @web3-ui/core ethers
 ```
 
 2. Setup the Provider

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -3,7 +3,7 @@
 A set of React components made for web3-specific use cases. Fully compatible with and built on top of ChakraUI.
 
 ```bash
-yarn add @web3-ui/components
+yarn add @web3-ui/components ethers
 ```
 
 ## Getting started

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,8 +41,8 @@
     "framer-motion": "^4"
   },
   "peerDependencies": {
-    "react": "*",
-    "react-dom": "*",
+    "react": ">= 16.8.0 | >= 17.0.0",
+    "react-dom": ">= 16.8.0 | >= 17.0.0",
     "ethers": "^5.5.2"
   },
   "devDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -38,12 +38,12 @@
     "@chakra-ui/react": "^1.7.2",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
-    "ethers": "^5.5.2",
     "framer-motion": "^4"
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*"
+    "react-dom": "*",
+    "ethers": "^5.5.2"
   },
   "devDependencies": {
     "@web3-ui/hooks": "^0.10.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,8 +44,7 @@
   },
   "peerDependencies": {
     "ethers": "^5.5.1",
-    "react": "*",
-    "react-dom": "*"
+    "react": ">= 16.8.0 | >= 17.0.0"
   },
   "devDependencies": {
     "@web3-ui/hooks": "^0.10.0",

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -3,7 +3,7 @@
 A set of React hooks developed for web3 use cases.
 
 ```bash
-yarn add @web3-ui/hooks
+yarn add @web3-ui/hooks ethers
 ```
 
 ## Getting started

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -38,12 +38,12 @@
   "dependencies": {
     "@babel/runtime": "^7.16.7",
     "@walletconnect/web3-provider": "^1.6.6",
-    "ethers": "^5.5.1",
     "web3modal": "^1.9.4"
   },
   "peerDependencies": {
     "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "react-dom": ">=16.8.0",
+    "ethers": "^5.5.1"
   },
   "devDependencies": {
     "@portis/web3": "^4.0.6",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -41,8 +41,7 @@
     "web3modal": "^1.9.4"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0",
+    "react": ">= 16.8.0 | >= 17.0.0",
     "ethers": "^5.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #220 

### ! **BREAKING CHANGE** !
This PR moves `ethers` to the peer dependencies for the `components` and `hooks` package.

This means that anyone who uses our packages will now also have to manually install `ethers` alongside our packages.

Why? Mainly to avoid dependency conflicts in cases when people already have `ethers` installed.