### PR TITLE
fix: save chainId on chainChanged event without formatting

### DIFF
--- a/.changeset/curvy-phones-agree.md
+++ b/.changeset/curvy-phones-agree.md
@@ -1,0 +1,6 @@
+---
+"@web3-ui/hooks": patch
+---
+
+closes #273
+fix: save chainId on chainChanged event without formatting

--- a/packages/hooks/src/Provider.tsx
+++ b/packages/hooks/src/Provider.tsx
@@ -119,7 +119,7 @@ export const Provider: React.FC<ProviderProps> = ({
       setConnected(true);
 
       connection.on('chainChanged', async (newChainId: string) => {
-        const formattedChainId = +newChainId.split('0x')[1];
+        const formattedChainId = +newChainId;
         setChainId(formattedChainId);
         setCorrectNetwork(formattedChainId === network);
         const provider = new ethers.providers.Web3Provider(connection);


### PR DESCRIPTION

Closes #273 

## Description

removed chainId formatting from `chainChanged` event. 
before -> chainId `0x89` would be saved as `89`.
after -> chainId `0x89` will be saved as `137`
