### PR TITLE
Fix: Next.js build

### DIFF
--- a/.changeset/spicy-zoos-drive.md
+++ b/.changeset/spicy-zoos-drive.md
@@ -1,0 +1,7 @@
+---
+'@web3-ui/components': patch
+'@web3-ui/core': patch
+'@web3-ui/hooks': patch
+---
+
+Fix some types/imports so that the packages work well with Next.js & ts

--- a/packages/components/src/components/AddressInput/AddressInput.tsx
+++ b/packages/components/src/components/AddressInput/AddressInput.tsx
@@ -8,7 +8,7 @@ import {
 import React, { useEffect, useState } from 'react';
 import { ethers } from 'ethers';
 import { useDebounce } from './useDebounce';
-import { JsonRpcSigner } from '@ethersproject/providers/src.ts/json-rpc-provider';
+import { JsonRpcSigner } from '@ethersproject/providers';
 
 export interface AddressInputProps {
   /**

--- a/packages/hooks/src/Provider.tsx
+++ b/packages/hooks/src/Provider.tsx
@@ -1,4 +1,4 @@
-import { JsonRpcSigner } from '@ethersproject/providers/src.ts/json-rpc-provider';
+import { JsonRpcSigner } from '@ethersproject/providers';
 import WalletConnectProvider from '@walletconnect/web3-provider';
 import { ethers } from 'ethers';
 import React, { createContext, useCallback, useMemo, useState } from 'react';

--- a/packages/hooks/src/hooks/useTransaction.ts
+++ b/packages/hooks/src/hooks/useTransaction.ts
@@ -15,7 +15,7 @@ import React from 'react';
  */
 
 export function useTransaction(
-  method
+  method: any
 ): [(args: any) => Promise<any>, boolean, any] {
   const [loading, setLoading] = React.useState<boolean>(false);
   const [error, setError] = React.useState<any>(null);

--- a/packages/hooks/src/hooks/useWallet.ts
+++ b/packages/hooks/src/hooks/useWallet.ts
@@ -68,7 +68,9 @@ export function useWallet() {
     error,
     connection: {
       userAddress,
-      network: CHAIN_ID_TO_NETWORK[chainId as number],
+      network: (CHAIN_ID_TO_NETWORK as { [key: number]: string })[
+        chainId as number
+      ],
       signer,
       ens,
     },


### PR DESCRIPTION
Closes #313 

## Description
Hey guys, dev #5843 here 🙌
I'm preparing a blogpost using [OpenZeppelin Defender](defender.openzeppelin.com) (which is where I work), and I decided to use Developer DAO's `web3-ui` package as my selected tool. Everything is pretty much done but I can't publish the article without publishing the build version of the project, and I need it to build with Next.js

I just changed what's causing type issues during the build, keeping every functionality untouched

## 📝 Additional Information

I've linked the local web3-ui package to my Next.js project and still doesn't compile but it passes the type checking (seems like this is more of a Next.js specific config to support `.ts` outside of the project), so it might me cool to export JS compiled files in another PR.
If I find a workaround for this I'll update the issue and add another PR if necessary. This fixes type checking as expected

EDIT: Workaround found https://github.com/Developer-DAO/web3-ui/issues/313#issuecomment-1058395460, so this PR completely fixes the Next.js build