### PR TITLE
Fix: Export missing core components from root components

### DIFF
--- a/.changeset/big-ladybugs-yawn.md
+++ b/.changeset/big-ladybugs-yawn.md
@@ -1,0 +1,5 @@
+---
+'@web3-ui/core': patch
+---
+
+Export missing core components on components root path

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -1,2 +1,4 @@
 export * from './ConnectWallet';
+export * from './NetworkSwitch';
 export * from './Provider';
+export * from './TokenBalance';


### PR DESCRIPTION
Closes #326 

## Description

Add missing exports on core/components/index.ts for the NetworkSwitch and TokenBalance components

