### PR TITLE
[hooks] Add `cacheProvider` prop to `<Provider />`

### DIFF
--- a/.changeset/strange-carrots-wonder.md
+++ b/.changeset/strange-carrots-wonder.md
@@ -1,0 +1,5 @@
+---
+'@web3-ui/hooks': minor
+---
+
+[hooks] `<Provider />` now exposes a `cacheProvider` prop to allow persistence with Web3Modal.

--- a/packages/hooks/src/stories/UseContract.stories.tsx
+++ b/packages/hooks/src/stories/UseContract.stories.tsx
@@ -141,7 +141,7 @@ const Default = () => {
 };
 
 storiesOf('Hooks/useWriteContract', module).add('Default', () => (
-  <Provider network={NETWORKS.rinkeby}>
+  <Provider network={NETWORKS.rinkeby} cacheProvider>
     <Default />
   </Provider>
 ));


### PR DESCRIPTION
See stories/useWriteContract for example.

Closes #310

## Description
This exposes cacheProvider as a prop to  `<Provider />` to allow persistence with Web3Modal.


## 📝 Additional Information

I'd like to implement some tests for this but wasn't sure how to mock accounts and didn't see any setup for that. Any ideas or examples on the best pattern to do that?

