### PR TITLE
fix: Stringify errors before rendering them

### DIFF
--- a/.changeset/fuzzy-countries-sniff.md
+++ b/.changeset/fuzzy-countries-sniff.md
@@ -1,0 +1,5 @@
+---
+'@web3-ui/components': patch
+---
+
+Fixed a crash happening due to errors not being stringified before being rendered

--- a/packages/components/src/components/Address/Address.tsx
+++ b/packages/components/src/components/Address/Address.tsx
@@ -122,7 +122,9 @@ export const Address: React.FC<AddressProps> = ({
           <CopyIcon marginLeft="auto" color="gray.300" />
         )}
       </Container>
-      <ErrorMessage className="Web3UI_Address__Error">{error}</ErrorMessage>
+      <ErrorMessage className="Web3UI_Address__Error">
+        {JSON.stringify(error)}
+      </ErrorMessage>
     </>
   );
 };

--- a/packages/components/src/components/AddressInput/AddressInput.tsx
+++ b/packages/components/src/components/AddressInput/AddressInput.tsx
@@ -120,7 +120,7 @@ export const AddressInput: React.FC<
       />
       {error && (
         <ErrorMessage className="Web3UI_AddressInput__ErrorMessage">
-          {error}
+          {JSON.stringify(error)}
         </ErrorMessage>
       )}
     </Container>


### PR DESCRIPTION
Closes #343 

## Description

This PR makes sure we are not rendering `Error` objects. We will now stringify them instead.
