### PR TITLE
:sparkles: [issue-366] Add TokenBalance component

### DIFF
--- a/apps/playground/pages/web3-components/index.tsx
+++ b/apps/playground/pages/web3-components/index.tsx
@@ -1,9 +1,29 @@
+import { useEffect, useState } from 'react';
 import type { NextPage } from 'next';
-import { Text, Address } from '@web3-ui/components/src';
+import { chain, useConnect, useAccount, useNetwork } from 'wagmi';
+
+import {
+  Button,
+  Flex,
+  Text,
+  Address,
+  TokenBalance,
+} from '@web3-ui/components/src';
+
+const UNI_TOKEN_ADDRESS = '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984';
 
 const Web3ComponentsPage: NextPage = () => {
+  const [mounted, setMounted] = useState(false);
+  const { chain: connectedChain } = useNetwork();
+  const allowENS = connectedChain?.id === chain.mainnet.id || !connectedChain;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   return (
     <main>
+      {mounted && <ConnectButton />}
       <div className={`section`}>
         <Text size={`xl`} as={`h3`} weight={'bold'} css={{ padding: '$2' }}>
           Components
@@ -22,8 +42,93 @@ const Web3ComponentsPage: NextPage = () => {
             copiable
           />
         </div>
+
+        <div className={`item`}>
+          <Text
+            size={`lg`}
+            as={`p`}
+            weight={'semibold'}
+            css={{ padding: '$4' }}
+          >
+            Token Balance:{' '}
+            {mounted && (connectedChain?.name || 'not connected')}
+          </Text>
+
+          {allowENS && (
+            <Flex>
+              <Text>
+                ENS <b>vitalik.eth</b>:&nbsp;
+              </Text>
+              <TokenBalance addressOrName="vitalik.eth" suspense={true} />
+            </Flex>
+          )}
+
+          <Flex>
+            <Text>
+              0x0 on <b>Polygon</b>:&nbsp;
+            </Text>
+            <TokenBalance
+              addressOrName="0x0000000000000000000000000000000000000000"
+              chainId={chain.polygon.id}
+              suspense={true}
+            />
+          </Flex>
+
+          {/*Example to avoid Hydration error - SSR specific
+          https://nextjs.org/docs/messages/react-hydration-error*/}
+          {mounted && allowENS && (
+            <Flex>
+              <Text>
+                Using <b>mounted</b> flag to manually avoid Hydration
+                error:&nbsp;
+              </Text>
+              <TokenBalance
+                addressOrName="andriishupta.eth"
+                token={UNI_TOKEN_ADDRESS}
+              />
+            </Flex>
+          )}
+
+          {mounted && (
+            <Flex>
+              <Text>Connected wallet:&nbsp;</Text>
+              <TokenBalance />
+            </Flex>
+          )}
+        </div>
       </div>
     </main>
+  );
+};
+
+const ConnectButton = () => {
+  const { connector: activeConnector, isConnected } = useAccount();
+  const { connect, connectors, error, isLoading, pendingConnector } =
+    useConnect();
+
+  return (
+    <>
+      {isConnected && <Text>Connected to {activeConnector?.name}</Text>}
+      {connectors
+        .filter((connector) => connector.id !== activeConnector?.id)
+        .map((connector) => (
+          <Button
+            disabled={!connector.ready}
+            key={connector.id}
+            onClick={() => connect({ connector })}
+          >
+            Connect to {connector.name}
+            {isLoading &&
+              pendingConnector?.id === connector.id &&
+              ' (connecting)'}
+          </Button>
+        ))}
+      {error && (
+        <Text>
+          Error <b>useConnect</b>: {error.message}
+        </Text>
+      )}
+    </>
   );
 };
 

--- a/packages/components/src/components/TokenBalance/TokenBalance.stories.tsx
+++ b/packages/components/src/components/TokenBalance/TokenBalance.stories.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { chain } from 'wagmi';
+
+import { TokenBalance } from './TokenBalance';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { WagmiDecorator } from '../../../../../apps/storybook/.storybook/decorator';
+
+const UNI_TOKEN_ADDRESS = '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984';
+
+export default {
+  title: 'Components/TokenBalance',
+  component: TokenBalance,
+  decorators: [WagmiDecorator],
+} as ComponentMeta<typeof TokenBalance>;
+
+export const Default: ComponentStory<typeof TokenBalance> = (args) => (
+  <TokenBalance {...args} />
+);
+
+export const AddressOrNameParam = () => (
+  <TokenBalance addressOrName="vitalik.eth" suspense={true} />
+);
+
+export const TokenParam = () => (
+  <TokenBalance
+    addressOrName="andriishupta.eth"
+    token={UNI_TOKEN_ADDRESS}
+    suspense={true}
+  />
+);
+
+export const ChainParam = () => (
+  <TokenBalance
+    addressOrName="0x0000000000000000000000000000000000000000"
+    chainId={chain.polygon.id}
+    suspense={true}
+  />
+);
+
+export const FormatParam = () => (
+  <TokenBalance
+    addressOrName="0x0000000000000000000000000000000000000000"
+    formatUnits={'gwei'}
+  />
+);

--- a/packages/components/src/components/TokenBalance/TokenBalance.test.tsx
+++ b/packages/components/src/components/TokenBalance/TokenBalance.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { publicProvider } from 'wagmi/providers/public';
+import { chain, configureChains, createClient, WagmiConfig } from 'wagmi';
+
+import { TokenBalance } from './TokenBalance';
+
+describe('TokenBalance', () => {
+  // TODO: do we need to somehow mock wagmiClient?
+
+  const { provider } = configureChains(
+    [chain.ropsten, chain.polygonMumbai],
+    [publicProvider()]
+  );
+
+  const client = createClient({
+    provider,
+  });
+
+  it('should render without throwing', async () => {
+    render(
+      <WagmiConfig client={client}>
+        <TokenBalance />
+      </WagmiConfig>
+    );
+
+    expect(await screen.findByText('Connect wallet')).toBeInTheDocument();
+  });
+
+  it('should render some testnet ETH value', async () => {
+    const { container } = render(
+      <WagmiConfig client={client}>
+        <TokenBalance addressOrName="0x0000000000000000000000000000000000000000" />
+      </WagmiConfig>
+    );
+
+    expect(container).toBeInTheDocument();
+  });
+
+  it('should render some testnet MATIC value', async () => {
+    const { container } = render(
+      <WagmiConfig client={client}>
+        <TokenBalance
+          addressOrName="0x0000000000000000000000000000000000000000"
+          chainId={chain.polygonMumbai.id}
+        />
+      </WagmiConfig>
+    );
+
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/components/TokenBalance/TokenBalance.tsx
+++ b/packages/components/src/components/TokenBalance/TokenBalance.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react';
+import { useAccount, useBalance } from 'wagmi';
+
+import { Text } from '../../common';
+
+type UseBalanceProps = NonNullable<Parameters<typeof useBalance>[0]>;
+export type TokenBalanceProps = Pick<
+  UseBalanceProps,
+  'addressOrName' | 'chainId' | 'token' | 'formatUnits' | 'watch' | 'suspense'
+>;
+
+export const TokenBalance: FC<TokenBalanceProps> = ({
+  addressOrName,
+  ...useBalanceProps
+}) => {
+  const { address } = useAccount();
+
+  const { data, isError, isLoading } = useBalance({
+    addressOrName: addressOrName ?? address,
+    ...useBalanceProps,
+  });
+
+  const noAddressParameter = !addressOrName && !address;
+  if (noAddressParameter) return <Text>Connect wallet</Text>;
+  if (isLoading) return <Text>Fetching balance...</Text>;
+  if (isError) return <Text>Error fetching balance</Text>;
+
+  return (
+    <Text>
+      {data?.formatted} {data?.symbol}
+    </Text>
+  );
+};

--- a/packages/components/src/components/TokenBalance/index.ts
+++ b/packages/components/src/components/TokenBalance/index.ts
@@ -1,0 +1,1 @@
+export * from './TokenBalance';

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -6,5 +6,5 @@ export * from './Address';
 // export * from './NFT';
 // export * from './AddressInput';
 // export * from './EtherInput';
-// export * from './TokenBalance';
+export * from './TokenBalance';
 // export * from './MultiAddressInput';


### PR DESCRIPTION
Closes #366

## Description
- add component / test / storybook
- add examples to the playground
- add connect button for testing

## How it works
It follows the same props as **wagmi's** `useBalance` hook with one difference: `addressOrName` is optional, and if it is skipped - we will try to take `address` from connected account

## Screenshots
### Playground
1) ![image](https://user-images.githubusercontent.com/10981565/182609179-cfa1e222-77ac-488f-b547-250466b854af.png)
2) ![image](https://user-images.githubusercontent.com/10981565/182609146-4503f61c-0c5d-4d0b-9cc5-8e9406d129b5.png)
3) ![image](https://user-images.githubusercontent.com/10981565/182609118-3d46dc64-9a29-4a0e-a9d4-2cd8c9f77c7c.png)

### Storybook
1) ![image](https://user-images.githubusercontent.com/10981565/182609284-87e085f1-a523-48a5-ac8d-58b21cd86dcf.png)
2) ![image](https://user-images.githubusercontent.com/10981565/182609317-066957de-a3f3-40c6-841a-2b17462486d9.png)

### Tests
![image](https://user-images.githubusercontent.com/10981565/182609605-e4613b91-9231-4341-b10f-ea68d1f24321.png)
